### PR TITLE
DPR-362 add controller backed by service returning static data

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,16 +1,42 @@
 plugins {
   id("org.jetbrains.kotlin.jvm") version "1.8.10"
-  application
+  id("io.micronaut.minimal.application") version "3.7.7"
+  id("kotlin-kapt")
+  id("com.github.johnrengelman.shadow") version "7.1.2"
+  // TODO - review global setup and ensure reports are on global coverage
+  id("jacoco")
 }
 
 repositories {
   mavenCentral()
 }
 
+micronaut {
+  version.set("3.8.7")
+}
+
+val kotlinVersion = "1.8.10"
+
 dependencies {
   implementation(project(":common"))
-  testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-  testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.1")
+
+  implementation("io.micronaut:micronaut-http-client")
+  implementation("io.micronaut:micronaut-jackson-databind")
+  implementation("io.micronaut:micronaut-runtime")
+  implementation("io.micronaut:micronaut-validation")
+  implementation("jakarta.annotation:jakarta.annotation-api")
+  implementation("io.micronaut:micronaut-http-server-netty")
+
+  runtimeOnly("ch.qos.logback:logback-classic")
+  compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
+  compileOnly("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+  kapt("io.micronaut:micronaut-inject-java")
+
+  kaptTest("io.micronaut:micronaut-inject-java")
+
+  testImplementation("io.micronaut.test:micronaut-test-junit5")
+  testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 }
 
 tasks.named<Test>("test") {
@@ -18,5 +44,5 @@ tasks.named<Test>("test") {
 }
 
 application {
-  mainClass.set("uk.gov.justice.digital.ExampleAppKt")
+  mainClass.set("uk.gov.justice.digital.DomainBuilderBackend")
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -26,13 +26,17 @@ dependencies {
   implementation("io.micronaut:micronaut-validation")
   implementation("jakarta.annotation:jakarta.annotation-api")
   implementation("io.micronaut:micronaut-http-server-netty")
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
 
   runtimeOnly("ch.qos.logback:logback-classic")
   compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
   compileOnly("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+
   kapt("io.micronaut:micronaut-inject-java")
+  kapt("io.micronaut:micronaut-http-validation")
 
   kaptTest("io.micronaut:micronaut-inject-java")
+  kaptTest("io.micronaut:micronaut-http-validation")
 
   testImplementation("io.micronaut.test:micronaut-test-junit5")
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")

--- a/backend/src/main/kotlin/uk/gov/justice/digital/DomainBuilderBackend.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/DomainBuilderBackend.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital
+
+import io.micronaut.runtime.Micronaut
+
+object DomainBuilderBackend {
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        Micronaut.run(DomainBuilderBackend::class.java)
+    }
+
+}

--- a/backend/src/main/kotlin/uk/gov/justice/digital/ExampleApp.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/ExampleApp.kt
@@ -1,5 +1,0 @@
-package uk.gov.justice.digital
-
-fun main() {
-    TODO("Not implemented yet - see DPR-362")
-}

--- a/backend/src/main/kotlin/uk/gov/justice/digital/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/controller/DomainController.kt
@@ -4,25 +4,21 @@ import io.micronaut.http.MediaType.APPLICATION_JSON
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.service.DomainService
 import java.util.*
 
 @Controller("/domain")
-class DomainController {
+class DomainController(private val service: DomainService) {
 
-    @Get(produces = [APPLICATION_JSON])
-    fun getDomains(): List<Domain> {
-        return listOf(Domain(
-            id = UUID.randomUUID(),
-            name = "Some domain",
-            description = "Static test domain",
-            version = "0.01",
-            location = "/some-domain",
-            tags = emptyMap(),
-            owner = "someone@example.come",
-            author = "someone@example.com",
-            originator = "someone@example.com",
-            tables = emptyList(),
-        ))
-   }
+    @Get("{?name}", produces = [APPLICATION_JSON])
+    fun getDomains(name: String?): List<Domain> {
+        return service.getDomains(name)
+    }
+
+    @Get("/{id}", produces = [APPLICATION_JSON])
+    // TODO - how do we raise a 404 if nothing is found?
+    fun getDomain(id: UUID): Domain? {
+        return service.getDomain(id)
+    }
 
 }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/controller/DomainController.kt
@@ -16,7 +16,6 @@ class DomainController(private val service: DomainService) {
     }
 
     @Get("/{id}", produces = [APPLICATION_JSON])
-    // TODO - how do we raise a 404 if nothing is found?
     fun getDomain(id: UUID): Domain? {
         return service.getDomain(id)
     }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/controller/DomainController.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.controller
+
+import io.micronaut.http.MediaType.APPLICATION_JSON
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import uk.gov.justice.digital.model.Domain
+import java.util.*
+
+@Controller("/domain")
+class DomainController {
+
+    @Get(produces = [APPLICATION_JSON])
+    fun getDomains(): List<Domain> {
+        return listOf(Domain(
+            id = UUID.randomUUID(),
+            name = "Some domain",
+            description = "Static test domain",
+            version = "0.01",
+            location = "/some-domain",
+            tags = emptyMap(),
+            owner = "someone@example.come",
+            author = "someone@example.com",
+            originator = "someone@example.com",
+            tables = emptyList(),
+        ))
+   }
+
+}

--- a/backend/src/main/kotlin/uk/gov/justice/digital/service/DomainService.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/service/DomainService.kt
@@ -1,0 +1,116 @@
+package uk.gov.justice.digital.service
+
+import jakarta.inject.Singleton
+import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Table
+import uk.gov.justice.digital.model.Transform
+import uk.gov.justice.digital.service.StaticData.domain1
+import uk.gov.justice.digital.service.StaticData.domain2
+import uk.gov.justice.digital.service.StaticData.domain3
+import java.util.*
+
+/**
+ * Initial service that will handle calls to the backend database.
+ *
+ * For now this just provides hardcoded data to support the development of the API.
+ *
+ * Part of DPR-362 - the work to build the REST API endpoints ultimately backed by a DB.
+ */
+@Singleton
+class DomainService {
+
+    private val domains = listOf(
+        domain1,
+        domain2,
+        domain3,
+    )
+
+    fun getDomains(
+        name: String? = null,
+        // TODO - additional filters will be specified in later work - see DPR-333
+    ): List<Domain> {
+        return domains.filter { domain ->
+            // If name is not null, check names for equality otherwise return true.
+            // This will allow us to handle multiple optional parameters easily in that null parameters will simply be
+            // ignored, and only those predicates with a value specified will be applied.
+            name?.let { it == domain.name } ?: true
+        }
+    }
+
+    fun getDomain(id: UUID): Domain? {
+        return domains.firstOrNull { it.id == id }
+    }
+
+}
+
+// Temporary hardcoded data - See DPR-363 for work to integrate with backend.
+object StaticData {
+
+    val EMAIL = "someone@example.com"
+
+    val tags = mapOf(
+        Pair("department", "ABCDEFG"),
+        Pair("unit", "Somewhere"),
+    )
+
+    val transform = Transform(
+        viewText = "SELECT source.table.field1, source.table.field2 FROM source.table",
+        sources = listOf("source.table"),
+    )
+
+    val table1 = Table(
+        name = "Table 1",
+        description = "A table containing some data",
+        version = "0.0.1",
+        location = "/table1",
+        tags = tags,
+        owner = EMAIL,
+        author = EMAIL,
+        primaryKey = "id",
+        transform = transform,
+        violations = emptyList(),
+    )
+
+    val table2 = table1.copy(
+        name = "Table 2",
+        description = "Another table containing some data",
+        location = "/table2",
+    )
+
+    val table3 = table1.copy(
+        name = "Table 3",
+        description = "Yet another table containing some data",
+        location = "/table3",
+        transform = transform.copy(sources = listOf("source.table", "anotherSource.anotherTable"))
+    )
+
+    val domain1 = Domain(
+        id = UUID.randomUUID(),
+        name = "Domain 1",
+        description = "A domain",
+        version = "0.0.1",
+        location = "/domain1",
+        tags = tags,
+        owner = EMAIL,
+        author = EMAIL,
+        originator = EMAIL,
+        tables = listOf(table1),
+    )
+
+    val domain2 = domain1.copy(
+        id = UUID.randomUUID(),
+        name = "Domain 2",
+        description = "Another domain",
+        location = "/domain2",
+        tables = listOf(table2, table3)
+    )
+
+    val domain3 = domain1.copy(
+        id = UUID.randomUUID(),
+        name = "Domain 3",
+        description = "Yet another domain",
+        location = "/domain3",
+        tables = listOf(table1, table2, table3)
+    )
+
+}

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration scan="true">
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+       <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+           <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-4level) %logger{36} %thread %msg %mdc %marker%n</pattern>
+       </encoder>
+   </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/backend/src/test/kotlin/uk/gov/justice/digital/controller/DomainControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/controller/DomainControllerTest.kt
@@ -15,13 +15,11 @@ import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.service.StaticData.domain1
 import uk.gov.justice.digital.service.StaticData.domain2
 import uk.gov.justice.digital.service.StaticData.domain3
-import java.lang.IllegalArgumentException
 import java.util.*
 
 @MicronautTest
 class DomainControllerTest {
 
-    // TODO - look into how micronaut handles de/ser
     private val mapper = jacksonObjectMapper()
 
     @Inject
@@ -45,17 +43,15 @@ class DomainControllerTest {
         assertEquals(domain1, parsed)
     }
 
-    // TODO - look into how to handle 4xx errors
     @Test
-    fun `GET of domain with non-existing ID should return not found`() {
+    fun `GET of domain with non-existing ID should throw a HttpClientResponseException`() {
         assertThrows(HttpClientResponseException::class.java) {
             client.toBlocking().retrieve(HttpRequest.GET<String>("/domain/${UUID.randomUUID()}"))
         }
     }
 
-    // TODO - look into how to handle 4xx errors
     @Test
-    fun `GET of domain with invalid ID should return bad request`() {
+    fun `GET of domain with invalid ID should throw an IllegalArgumentException`() {
         assertThrows(IllegalArgumentException::class.java) {
             client.toBlocking().retrieve(HttpRequest.GET<String>("/domain/this-is-not-a-UUID}"))
         }
@@ -69,7 +65,7 @@ class DomainControllerTest {
     }
 
     @Test
-    fun `GET of domain with non-existing name should return not found`() {
+    fun `GET of domain with non-existing name should return an empty list`() {
         val response: String = client.toBlocking().retrieve(HttpRequest.GET<String>("/domain?name=foo"))
         val parsed: List<Domain> = mapper.readValue(response)
         assertEquals(emptyList<Domain>(), parsed)

--- a/backend/src/test/kotlin/uk/gov/justice/digital/controller/DomainControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/controller/DomainControllerTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.controller
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class DomainControllerTest {
+
+    @Inject
+    private lateinit var server: EmbeddedServer
+
+    @Inject
+    @field:Client("/")
+    private lateinit var client: HttpClient
+
+    @Test
+    fun `GET domain should return all domains`() {
+        val response: String = client.toBlocking().retrieve(HttpRequest.GET<String>("/domain"))
+        assertTrue(response.contains("Some domain"))
+    }
+
+}

--- a/backend/src/test/kotlin/uk/gov/justice/digital/controller/DomainControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/controller/DomainControllerTest.kt
@@ -1,16 +1,28 @@
 package uk.gov.justice.digital.controller
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.service.StaticData.domain1
+import uk.gov.justice.digital.service.StaticData.domain2
+import uk.gov.justice.digital.service.StaticData.domain3
+import java.lang.IllegalArgumentException
+import java.util.*
 
 @MicronautTest
 class DomainControllerTest {
+
+    // TODO - look into how micronaut handles de/ser
+    private val mapper = jacksonObjectMapper()
 
     @Inject
     private lateinit var server: EmbeddedServer
@@ -20,9 +32,47 @@ class DomainControllerTest {
     private lateinit var client: HttpClient
 
     @Test
-    fun `GET domain should return all domains`() {
+    fun `GET of domain resource should return all domains`() {
         val response: String = client.toBlocking().retrieve(HttpRequest.GET<String>("/domain"))
-        assertTrue(response.contains("Some domain"))
+        val parsed: List<Domain> = mapper.readValue(response)
+        assertEquals(listOf(domain1, domain2, domain3), parsed)
+    }
+
+    @Test
+    fun `GET of domain with existing ID should return the domain with that ID`() {
+        val response: String = client.toBlocking().retrieve(HttpRequest.GET<String>("/domain/${domain1.id}"))
+        val parsed: Domain = mapper.readValue(response)
+        assertEquals(domain1, parsed)
+    }
+
+    // TODO - look into how to handle 4xx errors
+    @Test
+    fun `GET of domain with non-existing ID should return not found`() {
+        assertThrows(HttpClientResponseException::class.java) {
+            client.toBlocking().retrieve(HttpRequest.GET<String>("/domain/${UUID.randomUUID()}"))
+        }
+    }
+
+    // TODO - look into how to handle 4xx errors
+    @Test
+    fun `GET of domain with invalid ID should return bad request`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            client.toBlocking().retrieve(HttpRequest.GET<String>("/domain/this-is-not-a-UUID}"))
+        }
+    }
+
+    @Test
+    fun `GET of domain with existing name should return the domain with that name`() {
+        val response: String = client.toBlocking().retrieve(HttpRequest.GET<String>("/domain?name=Domain%201"))
+        val parsed: List<Domain> = mapper.readValue(response)
+        assertEquals(listOf(domain1), parsed)
+    }
+
+    @Test
+    fun `GET of domain with non-existing name should return not found`() {
+        val response: String = client.toBlocking().retrieve(HttpRequest.GET<String>("/domain?name=foo"))
+        val parsed: List<Domain> = mapper.readValue(response)
+        assertEquals(emptyList<Domain>(), parsed)
     }
 
 }

--- a/backend/src/test/kotlin/uk/gov/justice/digital/service/DomainServiceTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/service/DomainServiceTest.kt
@@ -1,5 +1,40 @@
 package uk.gov.justice.digital.service
 
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.service.StaticData.domain1
+import uk.gov.justice.digital.service.StaticData.domain2
+import uk.gov.justice.digital.service.StaticData.domain3
+import java.util.*
 
-class DomainServiceTest
+class DomainServiceTest {
+
+    private val underTest = DomainService()
+
+    @Test
+    fun `getDomains should return all domains when no filters are specified`() {
+        assertEquals(listOf(domain1, domain2, domain3), underTest.getDomains())
+    }
+
+    @Test
+    fun `getDomains should return a single domain when a name filter is specified and a matching domain exists`() {
+        assertEquals(listOf(domain3), underTest.getDomains(name = "Domain 3"))
+    }
+
+    @Test
+    fun `getDomains should return an empty list where no matching domain exists with the given name`() {
+        assertEquals(emptyList<Domain>(), underTest.getDomains(name = "no domain with this name exists"))
+    }
+
+    @Test
+    fun `getDomain should return a domain for the given UUID where a matching domain exists`() {
+        assertEquals(domain2, underTest.getDomain(domain2.id))
+    }
+
+    @Test
+    fun `getDomain should return null for the given UUID where no matching domain exists`() {
+        assertNull(underTest.getDomain(UUID.randomUUID()))
+    }
+
+}

--- a/backend/src/test/kotlin/uk/gov/justice/digital/service/DomainServiceTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/service/DomainServiceTest.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.service
+
+import org.junit.jupiter.api.Assertions.*
+
+class DomainServiceTest

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ListDomains.kt
@@ -42,7 +42,7 @@ class ListDomains(private val service: DomainService) : Runnable {
     }
 
     private fun generateOutput(data: List<Domain>): String {
-        val tableBorder = tableRowBorder(nameWidth, descriptionWidth, padding)
+        val tableBorder = tableRowBorder(nameWidth, descriptionWidth)
 
         val heading = listOf(
             "\n@|bold,green Found ${data.size} domains|@\n",

--- a/common/src/main/kotlin/uk/gov/justice/digital/model/Domain.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/model/Domain.kt
@@ -8,9 +8,9 @@ data class Domain(
     val description: String,
     val version: String,
     val location: String,
-    val tags: Map<String, String>,
+    val tags: Map<String, String> = emptyMap(),
     val owner: String,
     val author: String,
     val originator: String,
-    val tables: List<Table>,
+    val tables: List<Table> = emptyList(),
 )

--- a/common/src/main/kotlin/uk/gov/justice/digital/model/Table.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/model/Table.kt
@@ -5,10 +5,10 @@ data class Table(
     val description: String,
     val version: String,
     val location: String,
-    val tags: Map<String, String>,
+    val tags: Map<String, String> = emptyMap(),
     val owner: String,
     val author: String,
     val primaryKey: String,
     val transform: Transform,
-    val violations: List<String>,
+    val violations: List<String> = emptyList()
 )


### PR DESCRIPTION
Summary of changes
* backend now supports a `/domain` endpoint that returns all domains if no query parameters are specified
* added an optional `name` parameter e.g. `/domain?name=foo` that allows a domain for a given name to be found
* added a `/domain/<id>` endpoint that returns a given domain for the specified UUID
* introduced a service that for now returns hardcoded data (work to integrate postgres coming next)
* added controller and service tests