### PR TITLE
DPR 380 - resolve cli hang on exit issue

### DIFF
--- a/bin/domain-builder
+++ b/bin/domain-builder
@@ -12,7 +12,11 @@ source $script_dir/lib/script-helpers
 cd $script_dir/..
 
 show_wait "Building domain-builder..."
-./gradlew :cli:shadowJar -q &> /dev/null
-show_ok "Launching domain-builder  "
+if ./gradlew :cli:shadowJar -q &> /dev/null
+then
+  show_ok "Launching domain-builder  "
+else
+  show_fail_and_exit "Build failed              " "Run gradle build manually and review output"
+fi
 
 java -jar ./cli/build/libs/cli-*-all.jar $@

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
   implementation("info.picocli:picocli-shell-jline3:4.7.1")
   implementation("io.micronaut.picocli:micronaut-picocli")
   implementation("io.micronaut.serde:micronaut-serde-api:1.5.2")
-  implementation("io.micronaut:micronaut-http-client")
   implementation("io.micronaut:micronaut-jackson-databind")
   implementation("io.micronaut:micronaut-runtime")
   implementation("io.micronaut:micronaut-validation")
@@ -31,7 +30,6 @@ dependencies {
   implementation("org.fusesource.jansi:jansi:2.4.0")
   implementation(project(":common"))
   implementation("io.micronaut.reactor:micronaut-reactor")
-  implementation("io.micronaut.reactor:micronaut-reactor-http-client")
 
   kapt("io.micronaut.serde:micronaut-serde-processor:1.5.2")
   kapt("io.micronaut:micronaut-inject-java")

--- a/cli/src/main/kotlin/uk/gov/justice/digital/client/BlockingDomainClient.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/client/BlockingDomainClient.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.client
 
 import io.micronaut.context.annotation.Factory
-import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Value
 import io.micronaut.http.HttpHeaders.ACCEPT
 import io.micronaut.http.HttpHeaders.USER_AGENT
@@ -36,9 +35,11 @@ class BlockingDomainClient : DomainClient {
     private lateinit var client: HttpClient
 
     @Value("\${http.client.url}")
-    private val baseUrl = "http://localhost:8080"
+    private lateinit var baseUrl: String
 
-    private val DOMAIN_RESOURCE = UriBuilder.of("$baseUrl/domain").build()
+    private val DOMAIN_RESOURCE by lazy {
+        UriBuilder.of("$baseUrl/domain").build()
+    }
 
     override fun getDomains(): Array<Domain> = client.get<Array<Domain>>(DOMAIN_RESOURCE)
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ExceptionHandler.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ExceptionHandler.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.command
+
+import uk.gov.justice.digital.DomainBuilder
+
+object ExceptionHandler {
+
+    fun <T> runAndHandleExceptions(d: DomainBuilder, block: () -> T) {
+        try { block() }
+        catch (ex: Exception) {
+            d.print("""
+                
+                @|red,bold There was a problem with your request.|@
+                
+                Please try again later.
+                
+                Cause: @|red ${ex.localizedMessage}|@
+                 
+            """.trimIndent())
+        }
+    }
+
+}

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ListDomains.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.command
 import jakarta.inject.Singleton
 import picocli.CommandLine.*
 import uk.gov.justice.digital.DomainBuilder
+import uk.gov.justice.digital.command.ExceptionHandler.runAndHandleExceptions
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.service.DomainService
-
 
 @Singleton
 @Command(
@@ -28,9 +28,10 @@ class ListDomains(private val service: DomainService) : Runnable {
     private val defaultNameWidth = 20
     private val defaultDescriptionWidth = 60
 
-    override fun run() {
-        fetchAndDisplayDomains()
-    }
+    override fun run() =
+        runAndHandleExceptions(parent) {
+            fetchAndDisplayDomains()
+        }
 
     private fun fetchAndDisplayDomains() {
         val result = service.getAllDomains()

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
@@ -5,6 +5,7 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import picocli.CommandLine.ParentCommand
 import uk.gov.justice.digital.DomainBuilder
+import uk.gov.justice.digital.command.ExceptionHandler.runAndHandleExceptions
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.service.DomainService
 
@@ -39,12 +40,18 @@ class ViewDomain(private val service: DomainService) : Runnable {
     @ParentCommand
     lateinit var parent: DomainBuilder
 
-    override fun run() {
-        service.getDomainWithName(domainName())?.let {
-            val output = generateOutput(it)
-            parent.print(output)
-        } ?: parent.print("@|red,bold ERROR|@ - no domain with name '@|bold ${domainName()}|@' was found")
-    }
+    override fun run() =
+        runAndHandleExceptions(parent) {
+            service.getDomainWithName(domainName())?.let {
+                val output = generateOutput(it)
+                parent.print("$output\n")
+            } ?: parent.print("""
+                
+            @|red,bold ERROR|@ - no domain with name '@|bold ${domainName()}|@' was found
+            
+            
+            """.trimIndent())
+        }
 
     private fun generateOutput(domain: Domain): String {
         val heading = listOf(

--- a/cli/src/main/kotlin/uk/gov/justice/digital/session/ConsoleSession.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/session/ConsoleSession.kt
@@ -126,7 +126,7 @@ class InteractiveSession: ConsoleSession {
             
             Type @|bold exit|@ to exit the domain builder.
             
-            Press the @|bold TAB|@ key to view available commands or autocomplete commands as you type.
+            Press the @|bold TAB ->||@ key to view available commands or autocomplete commands as you type.
             
             
         """.trimIndent()

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -1,8 +1,3 @@
-micronaut:
-  http:
-    client:
-      read-timeout: 30s
-      connect-timeout: 30s
-    services:
-      domain:
-        url: ${DOMAIN_API_URL}
+http:
+  client:
+    url: ${DOMAIN_API_URL}

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
        </encoder>
    </appender>
 
-    <root level="ERROR">
+    <root level="OFF">
         <appender-ref ref="CONSOLE" />
     </root>
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/client/BlockingDomainClientTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/client/BlockingDomainClientTest.kt
@@ -73,8 +73,9 @@ class BlockingDomainClientTest {
     private fun createServerForScenario(scenario: String): EmbeddedServer {
         // Create an embedded server configured with the controller for the specified test scenario.
         val serverInstance = ApplicationContext.run(EmbeddedServer::class.java, mapOf(TEST_SCENARIO to scenario))
+        // Ensure the client is correctly configured
+        System.setProperty("http.client.url", "http://localhost:${serverInstance.port}")
         // Update configuration with embedded server port
-        System.setProperty("micronaut.http.services.domain.url", "http://localhost:${serverInstance.port}")
         serverInstance.applicationContext.environment.refresh()
         return serverInstance
     }

--- a/cli/src/test/resources/application.yml
+++ b/cli/src/test/resources/application.yml
@@ -1,8 +1,0 @@
-micronaut:
-  http:
-    client:
-      read-timeout: 30s
-      connect-timeout: 30s
-    services:
-      domain:
-        url: "http://localhost:8080"

--- a/docker/start-postgres
+++ b/docker/start-postgres
@@ -119,7 +119,7 @@ function check_or_create_database {
     show_wait "Database '$database_name' does not exist. Creating..."
     if run_psql_command "create database $database_name;" &> /dev/null
     then
-      show_ok "Database '$database_name' created"
+      show_ok "Database '$database_name' created                    "
     else
       show_fail_and_exit "Failed to create database '$database_name'" "Try creating the database '$database_name' manually."
     fi


### PR DESCRIPTION
Summary of changes
* micronaut uses netty under the hood which sets up a number of resources including a threadpool that doesn't get shutdown on exit - causing the process to hang after the user enters `exit`
* after some investigation there is no programmatic access via micronaut to force the shutdown and none of the available configuration settings resolved the issue
* the micronaut HttpClient has been replaced by the simpler HttpClient provided since Java 11
* updated tests and revised configuration
* tweaked script output