### PR TITLE
NOJIRA add check for additional postgres instances and fail if found

### DIFF
--- a/docker/start-postgres
+++ b/docker/start-postgres
@@ -14,6 +14,18 @@ database_name="domain_builder"  # name of database to create/connect to
 test_records=1000               # maximum number of test records to create
                                 # when domain table is empty
 
+function check_no_other_instances_running {
+  # Host on port check
+  process_count=$(lsof -nP -i4TCP | grep "5432 (LISTEN)" | tr -s ' ' | cut -d ' ' -f2 | xargs ps | grep -v "docker\|colima\|PID" | wc -l | tr -d ' ')
+  if [ "$process_count" -eq "0" ]
+  then
+    show_ok "No other postgres instances running"
+  else
+    process_list=$(lsof -nP -i4TCP | grep "5432 (LISTEN)" | tr -s ' ' | cut -d ' ' -f2 | xargs ps)
+    show_fail_and_exit "Other instances of postgres appear to be running" "Review the list of running instances below and ensure all other instances of\npostgres are stopped before continuing.\n\n$process_list"
+  fi
+}
+
 function check_docker_installed {
   if hash docker &> /dev/null
   then
@@ -111,26 +123,6 @@ function wait_for_postgres_to_start {
   show_ok "Postgres container $container_id running on local port 5432"
 }
 
-function check_no_other_instances_running {
-  # Docker PS check
-  instance_count=$(docker ps | grep postgres | wc -l | tr -d ' ')
-  if [ "$instance_count" -eq "1" ]
-  then
-    show_ok "No other postgres instances running on docker"
-  else
-    show_fail_and_exit "Additional postgres instances seem to be running" "Ensure all postgres docker containers are stopped before running this script again"
-  fi
-
-  # Host on port check
-  process_count=$(lsof -nP -i4TCP | grep "5432 (LISTEN)" | wc -l | tr -d ' ')
-  if [ "$process_count" -eq "1" ]
-  then
-    show_ok "No other postgres instances running on host"
-  else
-    process_list=$(lsof -nP -i4TCP | grep "5432 (LISTEN)" | tr -s ' ' | cut -d ' ' -f2 | xargs ps)
-    show_fail_and_exit "Other instances of postgres appear to be running" "Review the list of running instances below and ensure all other instances of\npostgres are stopped before continuing.\n\n$process_list"
-  fi
-}
 
 function check_or_create_database {
   if run_psql_command "\l" | grep "$database_name" &> /dev/null
@@ -206,6 +198,7 @@ function run_psql_query {
 echo
 show_heading "Checking prerequisites"
 echo
+check_no_other_instances_running
 check_docker_installed
 check_docker_compose_installed
 check_docker_daemon_available
@@ -215,7 +208,6 @@ echo
 check_docker_running
 start_postgres
 check_postgres_running
-check_no_other_instances_running
 echo
 show_heading "Configuring database"
 echo

--- a/docker/start-postgres
+++ b/docker/start-postgres
@@ -111,6 +111,27 @@ function wait_for_postgres_to_start {
   show_ok "Postgres container $container_id running on local port 5432"
 }
 
+function check_no_other_instances_running {
+  # Docker PS check
+  instance_count=$(docker ps | grep postgres | wc -l | tr -d ' ')
+  if [ "$instance_count" -eq "1" ]
+  then
+    show_ok "No other postgres instances running on docker"
+  else
+    show_fail_and_exit "Additional postgres instances seem to be running" "Ensure all postgres docker containers are stopped before running this script again"
+  fi
+
+  # Host on port check
+  process_count=$(lsof -nP -i4TCP | grep "5432 (LISTEN)" | wc -l | tr -d ' ')
+  if [ "$process_count" -eq "1" ]
+  then
+    show_ok "No other postgres instances running on host"
+  else
+    process_list=$(lsof -nP -i4TCP | grep "5432 (LISTEN)" | tr -s ' ' | cut -d ' ' -f2 | xargs ps)
+    show_fail_and_exit "Other instances of postgres appear to be running" "Review the list of running instances below and ensure all other instances of\npostgres are stopped before continuing.\n\n$process_list"
+  fi
+}
+
 function check_or_create_database {
   if run_psql_command "\l" | grep "$database_name" &> /dev/null
   then
@@ -194,6 +215,7 @@ echo
 check_docker_running
 start_postgres
 check_postgres_running
+check_no_other_instances_running
 echo
 show_heading "Configuring database"
 echo


### PR DESCRIPTION
Summary of changes
* added checks to ensure that
  * no other postgres containers are running
  * no other processes are listening on the postgres port 5432 on the host

This is in response to an issue found where an additional instance of postgres was running which was causing the script to fail. 