### PR TITLE
DPR-355 scripts updated to check for Java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ workflows:
           app: digital-prison-reporting-domain-builder
           app_artifacts_directory: build/libs/
           bucket_prefix: dpr-artifact-store
+          cache_key: "v5"
           notify_jira: false
           notify_slack: false
           channel: dpr_cicd_alerts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ workflows:
             branches:
               only: main
       - reporting/gradle_build_publish:
-          app: domain-builder-*
+          # TODO - fix this - setting to cli-frontend for now
+          #        sync script needs to handle multiple artifacts
+          app: domain-builder-cli-frontend
           app_artifacts_directory: build/libs/
           bucket_prefix: dpr-artifact-store
           cache_key: "v5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
             branches:
               only: main
       - reporting/gradle_build_publish:
-          app: digital-prison-reporting-domain-builder
+          app: domain-builder-*
           app_artifacts_directory: build/libs/
           bucket_prefix: dpr-artifact-store
           cache_key: "v5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  reporting: ministryofjustice/hmpps-reporting@1.0.9
+  reporting: ministryofjustice/hmpps-reporting@1.0.18
 
 workflows:
   checkout-build-publish:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project uses gradle which is bundled with the repository and also makes use
 - [docker](https://www.docker.com/) - to run postgres locally
 - [flyway](https://flywaydb.org/) - to manage database migrations
 
-The project is written in Kotlin and targets Java 11 since this is the latest 
+The project is written in Kotlin and targets Java 11 since this is the latest
 supported runtime available for AWS Lambdas. See [Building Lambda functions with Java](https://docs.aws.amazon.com/lambda/latest/dg/lambda-java.html).
 
 ## Local Development
@@ -214,7 +214,6 @@ Tests for a specific module can be run by specifying the module name. For exampl
 >
 > Refer to the [colima FAQ](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running)
 > for further information.
-
 
 ### Integration Tests
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This project uses gradle which is bundled with the repository and also makes use
 - [docker](https://www.docker.com/) - to run postgres locally
 - [flyway](https://flywaydb.org/) - to manage database migrations
 
-The project is written in Kotlin and targets Java 11.
+The project is written in Kotlin and targets Java 11 since this is the latest 
+supported runtime available for AWS Lambdas. See [Building Lambda functions with Java](https://docs.aws.amazon.com/lambda/latest/dg/lambda-java.html).
 
 ## Local Development
 
@@ -205,6 +206,15 @@ Tests for a specific module can be run by specifying the module name. For exampl
 ```
     ./gradlew :backend:test
 ```
+
+> _Note_ Some of the backend tests need a running docker daemon. If you're using
+> [colima](https://github.com/abiosoft/colima) you will need to run the following
+> `sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock` in order
+> for the tests to run.
+>
+> Refer to the [colima FAQ](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running)
+> for further information.
+
 
 ### Integration Tests
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -84,8 +84,7 @@ tasks {
 
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-backend-api")
-    val target = project.rootDir.toPath().resolve("build/libs")
-    destinationDirectory.set(File(target.toString()))
+    destinationDirectory.set(File("${project.rootDir}/build/libs"))
   }
 
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -91,12 +91,6 @@ tasks {
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-backend-api")
     destinationDirectory.set(File("${project.rootDir}/build/libs"))
-    doLast {
-      println("backend: build/libs contents")
-      File("${project.rootDir}/build/libs")
-              .list()
-              ?.forEach { s -> println(s) }
-    }
   }
 
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -82,6 +82,12 @@ tasks {
     useJUnitPlatform()
   }
 
+  // TODO - temporary fudge for the sync script which expects both jars to be present
+  named<Jar>("jar") {
+    archiveBaseName.set("domain-builder-backend-api")
+    destinationDirectory.set(File("${project.rootDir}/build/libs"))
+  }
+
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-backend-api")
     destinationDirectory.set(File("${project.rootDir}/build/libs"))

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -85,6 +85,12 @@ tasks {
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-backend-api")
     destinationDirectory.set(File("${project.rootDir}/build/libs"))
+    doLast {
+      println("backend: build/libs contents")
+      File("${project.rootDir}/build/libs")
+              .list()
+              ?.forEach { s -> println(s) }
+    }
   }
 
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -84,6 +84,8 @@ tasks {
 
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-backend-api")
+    val target = project.rootDir.toPath().resolve("build/libs")
+    destinationDirectory.set(File(target.toString()))
   }
 
 }

--- a/bin/apply-migrations
+++ b/bin/apply-migrations
@@ -63,6 +63,7 @@ function apply_migrations {
 echo
 show_heading "Applying migrations"
 echo
+check_java_version
 determine_jar_path
 run_build_and_check_jar_exists
 apply_migrations

--- a/bin/domain-builder
+++ b/bin/domain-builder
@@ -31,4 +31,4 @@ fi
 
 show_ok "domain-builder will use api: $DOMAIN_API_URL"
 
-java -jar ./cli/build/libs/cli-*-all.jar $@
+java -jar ./build/libs/domain-builder-cli-frontend-*-all.jar $@

--- a/bin/domain-builder
+++ b/bin/domain-builder
@@ -11,6 +11,7 @@ source $script_dir/lib/script-helpers
 
 cd $script_dir/..
 
+check_java_version
 show_wait "Building domain-builder..."
 if ./gradlew :cli:shadowJar -q &> /dev/null
 then

--- a/bin/lib/script-helpers
+++ b/bin/lib/script-helpers
@@ -36,3 +36,27 @@ run_with_local_postgres_config() {
     POSTGRES_PASSWORD="postgres" \
     $@
 }
+
+function check_java_version {
+  show_wait "Checking java version..."
+  major_version=$(java -version 2> >(grep version) | cut -f2 -d '"' | cut -f1 -d '.')
+  if [ "$major_version" -eq "11" ]
+  then
+    show_ok "JAVA_HOME is pointing to a valid Java 11 installation"
+  else
+    if [ $(uname) == "Darwin" ]
+    then
+      show_warn "Got Java $major_version when Java 11 needed, attempting to fix"
+      export JAVA_HOME=$(/usr/libexec/java_home -v "11")
+      version=$(java -version 2> >(grep version) | cut -f2 -d '"' | cut -f1 -d '.')
+      if [ "$version" -eq "11" ]
+      then
+        show_ok "JAVA_HOME is now pointing to a valid Java 11 installation"
+      else
+        show_fail_and_exit "Got Java $major_version when Java 11 needed" "Please ensure your JAVA_HOME is set and pointing to a valid Java 11 installation"
+      fi
+    else
+      show_fail_and_exit "Got Java $major_version when Java 11 needed" "Please ensure your JAVA_HOME is set and pointing to a valid Java 11 installation"
+    fi
+  fi
+}

--- a/bin/run-backend
+++ b/bin/run-backend
@@ -11,7 +11,7 @@
 set -e
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-jar_path="$script_dir/../backend/build/libs/domain-builder-backend-api-*-all.jar"
+jar_path="$script_dir/../build/libs/domain-builder-backend-api-*-all.jar"
 
 source "$script_dir/../bin/lib/script-helpers"
 

--- a/bin/run-backend
+++ b/bin/run-backend
@@ -53,6 +53,7 @@ function check_jar_exists {
 echo
 show_heading "Launching backend api"
 echo
+check_java_version
 check_postgres_running
 build_backend
 check_jar_exists
@@ -62,9 +63,4 @@ echo
 echo "[Press CTRL-C to exit]"
 echo
 
-#POSTGRES_HOST="localhost" \
-#  POSTGRES_PORT="5432" \
-#  POSTGRES_DB_NAME="domain_builder" \
-#  POSTGRES_USERNAME="postgres" \
-#  POSTGRES_PASSWORD="postgres" \
-run_with_local_postgres_config  "java -jar $jar_path"
+run_with_local_postgres_config "java -jar $jar_path"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.gradle.testing.jacoco.tasks.JacocoReport
 
 plugins {
   id("org.jetbrains.kotlin.jvm") version "1.8.10"
@@ -38,3 +37,4 @@ subprojects {
     }
   }
 }
+

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -65,6 +65,12 @@ tasks {
     standardInput = System.`in`
   }
 
+  // TODO - temporary fudge for the sync script which expects both jars to be present
+  named<Jar>("jar") {
+    archiveBaseName.set("domain-builder-cli-frontend")
+    destinationDirectory.set(File("${project.rootDir}/build/libs"))
+  }
+
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-cli-frontend")
     destinationDirectory.set(File("${project.rootDir}/build/libs"))

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -67,8 +67,7 @@ tasks {
 
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-cli-frontend")
-    val target = project.rootDir.toPath().resolve("build/libs")
-    destinationDirectory.set(File(target.toString()))
+    destinationDirectory.set(File("${project.rootDir}/build/libs"))
   }
 
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -68,6 +68,12 @@ tasks {
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-cli-frontend")
     destinationDirectory.set(File("${project.rootDir}/build/libs"))
+    doLast {
+      println("cli: build/libs contents")
+      File("${project.rootDir}/build/libs")
+              .list()
+              ?.forEach { s -> println(s) }
+    }
   }
 
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -74,12 +74,6 @@ tasks {
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-cli-frontend")
     destinationDirectory.set(File("${project.rootDir}/build/libs"))
-    doLast {
-      println("cli: build/libs contents")
-      File("${project.rootDir}/build/libs")
-              .list()
-              ?.forEach { s -> println(s) }
-    }
   }
 
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id("org.jetbrains.kotlin.jvm") version "1.8.10"
   id("io.micronaut.minimal.application") version "3.7.7"
@@ -48,15 +50,25 @@ dependencies {
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 }
 
-tasks.named<Test>("test") {
-  useJUnitPlatform()
-}
 
 application {
   mainClass.set("uk.gov.justice.digital.DomainBuilder")
 }
 
-tasks.named<JavaExec>("run") {
-  // Ensure we attach STDIN so interactive mode works when using the run task
-  standardInput = System.`in`
+tasks {
+  named<Test>("test") {
+    useJUnitPlatform()
+  }
+
+  named<JavaExec>("run") {
+    // Ensure we attach STDIN so interactive mode works when using the run task
+    standardInput = System.`in`
+  }
+
+  named<ShadowJar>("shadowJar") {
+    archiveBaseName.set("domain-builder-cli-frontend")
+    val target = project.rootDir.toPath().resolve("build/libs")
+    destinationDirectory.set(File(target.toString()))
+  }
+
 }

--- a/docker/start-postgres
+++ b/docker/start-postgres
@@ -198,6 +198,7 @@ function run_psql_query {
 echo
 show_heading "Checking prerequisites"
 echo
+check_java_version
 check_no_other_instances_running
 check_docker_installed
 check_docker_compose_installed

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
-rootProject.name = "domainBuilder"
+rootProject.name = "domain-builder"
 include("common", "backend", "cli")


### PR DESCRIPTION
Summary of changes
* added Java 11 check for the domain builder scripts
* if running on a mac we also try to use `libexec` to set the `JAVA_HOME` to a Java 11 installation
* other revisions to get the circle ci build to pass - some temporary changes until I get confirmation from HariC wrt the sync artifacts script (for now I've set the project name to trick it into syncing the cli frontend only so the build passes)