### PR TITLE
DPR-513 add support for Domain Status attribute

### DIFF
--- a/backend/src/main/kotlin/uk/gov/justice/digital/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/controller/DomainController.kt
@@ -4,15 +4,16 @@ import io.micronaut.http.MediaType.APPLICATION_JSON
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.service.DomainService
 import java.util.*
 
 @Controller("/domain")
 class DomainController(private val service: DomainService) {
 
-    @Get("{?name}", produces = [APPLICATION_JSON])
-    fun getDomains(name: String?): List<Domain> {
-        return service.getDomains(name)
+    @Get("{?name,status}", produces = [APPLICATION_JSON])
+    fun getDomains(name: String?, status: Status?): List<Domain> {
+        return service.getDomains(name, status)
     }
 
     @Get("/{id}", produces = [APPLICATION_JSON])

--- a/backend/src/main/kotlin/uk/gov/justice/digital/repository/DomainRepository.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/repository/DomainRepository.kt
@@ -4,6 +4,7 @@ import jakarta.inject.Singleton
 import org.ktorm.database.Database
 import org.ktorm.dsl.*
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.repository.table.DomainTable
 import uk.gov.justice.digital.time.ClockProvider
 import java.util.*
@@ -26,13 +27,13 @@ class DomainRepository(dataSource: DataSource, clockProvider: ClockProvider) {
             .firstOrNull()
     }
 
-    // TODO - this needs to support state too
-    fun getDomains(name: String? = null): List<Domain> {
+    fun getDomains(name: String? = null, status: Status? = null): List<Domain> {
         return database
             .from(DomainTable)
             .select(DomainTable.data)
             .whereWithConditions { conditions ->
                 name?.let { conditions += DomainTable.name eq it }
+                status?.let { conditions += DomainTable.status eq it }
             }
             .map { it[DomainTable.data] }
             .filterNotNull()

--- a/backend/src/main/kotlin/uk/gov/justice/digital/repository/table/DomainTable.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/repository/table/DomainTable.kt
@@ -3,10 +3,12 @@ package uk.gov.justice.digital.repository.table
 import org.ktorm.jackson.json
 import org.ktorm.schema.*
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Status
 
 object DomainTable : Table<Nothing>("domain") {
     val id = uuid("id").primaryKey()
     val name = varchar("name")
+    val status = enum<Status>("status")
     val data = json<Domain>("data")
     val created = timestamp("created")
     val lastUpdated = timestamp("lastupdated")

--- a/backend/src/main/kotlin/uk/gov/justice/digital/service/RepositoryBackedDomainService.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/service/RepositoryBackedDomainService.kt
@@ -2,11 +2,12 @@ package uk.gov.justice.digital.service
 
 import jakarta.inject.Singleton
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.repository.DomainRepository
 import java.util.*
 
 interface DomainService {
-    fun getDomains(name: String? = null): List<Domain>
+    fun getDomains(name: String? = null, status: Status? = null): List<Domain>
     fun getDomain(id: UUID): Domain?
 }
 
@@ -18,6 +19,6 @@ interface DomainService {
  */
 @Singleton
 class RepositoryBackedDomainService(private val repository: DomainRepository): DomainService {
-    override fun getDomains(name: String?): List<Domain> = repository.getDomains(name)
+    override fun getDomains(name: String?, status: Status?): List<Domain> = repository.getDomains(name)
     override fun getDomain(id: UUID): Domain? = repository.getDomain(id)
 }

--- a/backend/src/main/resources/db/migration/V002__add_status_column.sql
+++ b/backend/src/main/resources/db/migration/V002__add_status_column.sql
@@ -1,0 +1,6 @@
+create type status as enum ('DRAFT', 'PUBLISHED');
+
+alter table domain
+add column status status not null default 'DRAFT'
+
+

--- a/backend/src/main/resources/db/migration/V003__unique_constraint_now_on_name_and_status.sql
+++ b/backend/src/main/resources/db/migration/V003__unique_constraint_now_on_name_and_status.sql
@@ -1,0 +1,3 @@
+alter table domain
+    add constraint unique_name_and_status_constraint unique (name, status),
+    drop constraint unique_key_name;

--- a/backend/src/test/kotlin/uk/gov/justice/digital/controller/DomainControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/controller/DomainControllerTest.kt
@@ -18,6 +18,7 @@ import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.service.DomainService
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domains
@@ -142,6 +143,30 @@ class DomainControllerTest {
         assertEquals(emptyList<Domain>(), response.parsedBody())
 
         verify { mockDomainService.getDomains(nonExistingName) }
+    }
+
+    @Test
+    fun `GET of domain with status should return any domains with that status`() {
+        every { mockDomainService.getDomains(status = eq(Status.DRAFT)) } returns listOf(domain1)
+
+        val response = get("/domain?status=DRAFT")
+
+        assertEquals(OK, response.status)
+        assertEquals(listOf(domain1), response.parsedBody<List<Domain>>())
+
+        verify { mockDomainService.getDomains(status = eq(Status.DRAFT)) }
+    }
+
+    @Test
+    fun `GET of domain with name and status should return a matching domain where it exists`() {
+        every { mockDomainService.getDomains(eq(domain1.name), eq(domain1.status)) } returns listOf(domain1)
+
+        val response = get("/domain?name=Domain%201&status=DRAFT")
+
+        assertEquals(OK, response.status)
+        assertEquals(listOf(domain1), response.parsedBody<List<Domain>>())
+
+        verify { mockDomainService.getDomains(eq(domain1.name), eq(domain1.status)) }
     }
 
     private fun get(location: String): HttpResponse<String> =

--- a/backend/src/test/kotlin/uk/gov/justice/digital/repository/DomainRepositoryTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/repository/DomainRepositoryTest.kt
@@ -11,9 +11,13 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domain2
 import uk.gov.justice.digital.test.Fixtures.domain3
+import uk.gov.justice.digital.test.Fixtures.publishedDomain1
+import uk.gov.justice.digital.test.time.FixedClock
+import java.time.Instant
 import java.util.*
 
 // This test needs a local docker daemon to be running.
@@ -58,11 +62,32 @@ class DomainRepositoryTest {
             .executeUpdate("truncate table domain")
     }
 
-    private val underTest by lazy { DomainRepository(dataSource) }
+    private val fixedClock = FixedClock().clock
+
+    private val underTest by lazy { DomainRepository(dataSource, FixedClock()) }
 
     @Test
     fun `createDomain should succeed for a successful insert`() {
         assertDoesNotThrow { underTest.createDomain(domain1) }
+    }
+
+    @Test
+    fun `createDomain should set timestamps where none are provided`() {
+        underTest.createDomain(domain1)
+        val retrievedDomain = underTest.getDomain(domain1.id)
+        assertEquals(fixedClock.instant(), retrievedDomain?.created)
+        assertEquals(fixedClock.instant(), retrievedDomain?.lastUpdated)
+    }
+
+    @Test
+    fun `createDomain should use provided timestamps where provided`() {
+        val ts = fixedClock.instant().plusSeconds(55)
+        val domainWithTimestamps = domain1.copy(
+                created = ts,
+                lastUpdated = ts,
+        )
+        underTest.createDomain(domainWithTimestamps)
+        assertEquals(domainWithTimestamps, underTest.getDomain(domainWithTimestamps.id))
     }
 
     @Test
@@ -75,9 +100,24 @@ class DomainRepositoryTest {
     }
 
     @Test
-    fun `getDomain should return a Domain where a domain for the UUID exists`() {
+    fun `createDomain should allow a domain name to be used again given a different state`() {
         underTest.createDomain(domain1)
-        assertEquals(domain1, underTest.getDomain(domain1.id))
+        assertDoesNotThrow {
+            // This second assert should succeed
+            underTest.createDomain(publishedDomain1)
+        }
+    }
+
+    @Test
+    fun getDomainShouldReturnADomainWhereADomainForTheUUIDExists() {
+        underTest.createDomain(domain1)
+        val retrievedDomain = underTest.getDomain(domain1.id)
+        assertNotNull(retrievedDomain)
+        // Verify that the timestamps are set
+        assertNotNull(retrievedDomain?.created, "created timestamp should be set")
+        assertNotNull(retrievedDomain?.lastUpdated, "lastUpdated timestamp should be set")
+        // For comparison with the fixture set the timestamps to null.
+        assertEquals(domain1, retrievedDomain?.copy(created = null, lastUpdated = null))
     }
 
     @Test
@@ -90,14 +130,16 @@ class DomainRepositoryTest {
     fun `getDomains should return all Domains where no arguments provided`() {
         val domains = listOf(domain1, domain2, domain3)
         domains.forEach { underTest.createDomain(it) }
-        assertEquals(domains, underTest.getDomains())
+        // After creation all domains will also have a created and lastupdated timestamp.
+        val expectedDomains = domains.map { it.setTimestamps(fixedClock.instant()) }
+        assertEquals(expectedDomains, underTest.getDomains())
     }
 
     @Test
     fun `getDomains should return a single domain where a name is specified which matches an existing Domain`() {
-        val domains = listOf(domain1, domain2, domain3)
-        domains.forEach { underTest.createDomain(it) }
-        assertEquals(listOf(domain3), underTest.getDomains(name = domain3.name))
+        listOf(domain1, domain2, domain3).forEach { underTest.createDomain(it) }
+        val expected = domain3.setTimestamps(fixedClock.instant())
+        assertEquals(listOf(expected), underTest.getDomains(name = domain3.name))
     }
 
     @Test
@@ -125,16 +167,21 @@ class DomainRepositoryTest {
         val domains = listOf(domain1, domain2, domain3)
         domains.forEach { underTest.createDomain(it) }
 
-        val updatedDomain = domain1.copy(
-            description = "This is an updated description for the domain"
-        )
+        val updatedDomain = underTest.getDomain(domain1.id)?.copy(
+            description = "This is an updated description for the domain",
+            status = Status.PUBLISHED,
+        )!!
 
         assertDoesNotThrow { underTest.updateDomain(updatedDomain) }
-        assertEquals(updatedDomain, underTest.getDomain(domain1.id))
+        assertEquals(updatedDomain.setTimestamps(fixedClock.instant()), underTest.getDomain(domain1.id))
+
         // Verify that the other domains are unaffected by the update.
         listOf(domain2, domain3).forEach {
-            assertEquals(it, underTest.getDomain(it.id))
+            assertEquals(it.setTimestamps(fixedClock.instant()), underTest.getDomain(it.id))
         }
+
+        // As a final check, verify that we can insert another domain with the same name, but with the draft state.
+        assertDoesNotThrow { underTest.createDomain(domain1.copy(id = UUID.randomUUID())) }
     }
 
     @Test
@@ -144,6 +191,10 @@ class DomainRepositoryTest {
         )
         assertThrows(UpdateFailedException::class.java) { underTest.updateDomain(updatedDomain) }
         assertNull( underTest.getDomain(domain1.id))
+    }
+
+    private fun Domain.setTimestamps(ts: Instant): Domain {
+        return this.copy(created = ts, lastUpdated = ts)
     }
 
 }

--- a/bin/apply-migrations
+++ b/bin/apply-migrations
@@ -38,18 +38,20 @@ function run_build_and_check_jar_exists {
       show_fail_and_exit "Build failed            " "Run ./gradlew :backend:shadowJar and review output."
     fi
 
-    jar_path=$(find backend/build/libs -name '*-all.jar')
-    if [ -e $jar_path ]
+    jar_path=$(find build/libs -name '*domain-builder-backend-api-*-all.jar')
+
+    if [ -z $jar_path ]
     then
-      show_ok "Located local jar file: $jar_path"
-    else
       show_fail_and_exit "Build failed            " "Run ./gradlew :backend:shadowJar and review output."
+    else
+      show_ok "Located local jar file: $jar_path"
     fi
   fi
 }
 
 function apply_migrations {
   log_file="/tmp/migration-log-$(date +'%Y-%m-%dT%H:%M:%S').log"
+  show_info "Launching $jar_path"
   show_wait "Applying migrations..."
   if run_with_local_postgres_config java -cp $jar_path uk.gov.justice.digital.MigrationRunner &> $log_file
   then

--- a/bin/domain-builder
+++ b/bin/domain-builder
@@ -31,4 +31,6 @@ fi
 
 show_ok "domain-builder will use api: $DOMAIN_API_URL"
 
+# TODO - check backend API is up
+
 java -jar ./build/libs/domain-builder-cli-frontend-*-all.jar $@

--- a/bin/domain-builder
+++ b/bin/domain-builder
@@ -12,7 +12,9 @@ source $script_dir/lib/script-helpers
 cd $script_dir/..
 
 check_java_version
+
 show_wait "Building domain-builder..."
+
 if ./gradlew :cli:shadowJar -q &> /dev/null
 then
   show_ok "Launching domain-builder  "
@@ -31,6 +33,13 @@ fi
 
 show_ok "domain-builder will use api: $DOMAIN_API_URL"
 
-# TODO - check backend API is up
+show_wait "Testing $DOMAIN_API_URL..."
+
+if curl $DOMAIN_API_URL &> /dev/null
+then
+  show_ok "Backend API is available                            "
+else
+  show_fail_and_exit "Backend API is not available     " "Run bin/run-backend to start Backend API"
+fi
 
 java -jar ./build/libs/domain-builder-cli-frontend-*-all.jar $@

--- a/bin/lib/script-helpers
+++ b/bin/lib/script-helpers
@@ -42,16 +42,16 @@ function check_java_version {
   major_version=$(java -version 2> >(grep version) | cut -f2 -d '"' | cut -f1 -d '.')
   if [ "$major_version" -eq "11" ]
   then
-    show_ok "JAVA_HOME is pointing to a valid Java 11 installation"
+    show_ok "Java 11 is already configured"
   else
     if [ $(uname) == "Darwin" ]
     then
-      show_warn "Found Java $major_version when Java 11 required, trying fix"
+      show_warn "Found Java $major_version when Java 11 required - attempting to use Java 11"
       export JAVA_HOME=$(/usr/libexec/java_home -v "11")
       version=$(java -version 2> >(grep version) | cut -f2 -d '"' | cut -f1 -d '.')
       if [ "$version" -eq "11" ]
       then
-        show_ok "JAVA_HOME is now pointing to a valid Java 11 installation"
+        show_ok "Java 11 is now configured for this run"
       else
         show_fail_and_exit "Got Java $major_version when Java 11 needed" "Please ensure your JAVA_HOME is set and pointing to a valid Java 11 installation"
       fi

--- a/bin/lib/script-helpers
+++ b/bin/lib/script-helpers
@@ -46,7 +46,7 @@ function check_java_version {
   else
     if [ $(uname) == "Darwin" ]
     then
-      show_warn "Got Java $major_version when Java 11 needed, attempting to fix"
+      show_warn "Found Java $major_version when Java 11 required, trying fix"
       export JAVA_HOME=$(/usr/libexec/java_home -v "11")
       version=$(java -version 2> >(grep version) | cut -f2 -d '"' | cut -f1 -d '.')
       if [ "$version" -eq "11" ]

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ListDomains.kt
@@ -25,8 +25,9 @@ class ListDomains(private val service: DomainService) : Runnable {
     lateinit var parent: DomainBuilder
 
     private val padding = 2
-    private val defaultNameWidth = 20
-    private val defaultDescriptionWidth = 60
+    private val defaultNameWidth = 4
+    private val defaultStatusWidth = 6
+    private val defaultDescriptionWidth = 10
 
     override fun run() =
         runAndHandleExceptions(parent) {
@@ -44,18 +45,21 @@ class ListDomains(private val service: DomainService) : Runnable {
 
     private fun generateOutput(data: List<Domain>): String {
         // Format name and description widths dynamically
-        val nameWidth = data.maxOfOrNull { it.name.length } ?: defaultNameWidth
-        val descriptionWidth = data.maxOfOrNull { it.description.length } ?: defaultDescriptionWidth
+        val nameWidth = data.maxOf { it.name.length }.let { if (it > defaultNameWidth) it else defaultNameWidth }
+        val statusWidth = data.maxOf { it.status.name.length }.let { if (it > defaultStatusWidth) it else defaultStatusWidth }
+        val descriptionWidth = data.maxOf { it.description.length }.let { if (it > defaultDescriptionWidth) it else defaultDescriptionWidth }
 
-        val tableBorder = tableRowBorder(nameWidth, descriptionWidth)
+        val tableBorder = tableRowBorder(nameWidth, statusWidth, descriptionWidth)
 
         val heading = listOf(
             "\n@|bold,green Found ${data.size} domains|@\n",
             tableBorder,
-            String.format("| @|bold %-${nameWidth}s|@ | @|bold %-${descriptionWidth}s|@ |", "Name", "Description"),
+            String.format("| @|bold %-${nameWidth}s|@ | @|bold %-${statusWidth}s|@ | @|bold %-${descriptionWidth}s|@ |", "Name", "Status", "Description"),
             tableBorder,
         )
-        val dataRows = data.map { String.format("| %-${nameWidth}s | %-${descriptionWidth}s |", it.name, it.description) }
+        val dataRows = data.map {
+            String.format(
+                "| %-${nameWidth}s | %-${statusWidth}s | %-${descriptionWidth}s |", it.name, it.status, it.description) }
         val footer = listOf("$tableBorder\n")
 
         return listOf(heading, dataRows, footer)

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ListDomains.kt
@@ -43,7 +43,7 @@ class ListDomains(private val service: DomainService) : Runnable {
         else parent.print(output)
     }
 
-    private fun generateOutput(data: List<Domain>): String {
+    private fun generateOutput(data: Array<Domain>): String {
         // Format name and description widths dynamically
         val nameWidth = data.maxOf { it.name.length }.let { if (it > defaultNameWidth) it else defaultNameWidth }
         val statusWidth = data.maxOf { it.status.name.length }.let { if (it > defaultStatusWidth) it else defaultStatusWidth }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
@@ -45,7 +45,7 @@ class ViewDomain(private val service: DomainService) : Runnable {
                 val output = generateOutput(it)
                 parent.print("$output\n")
             } ?: parent.print("""
-                
+            
             @|red,bold ERROR|@ - no domain with name '@|bold ${domainName()}|@' was found
             
             

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
@@ -59,7 +59,8 @@ class ViewDomain(private val service: DomainService) : Runnable {
             """
                @|bold Name        |@| ${domain.name} 
                @|bold Description |@| ${domain.description}
-               @|bold Originator  |@| ${domain.originator}
+               @|bold Owner       |@| ${domain.owner}
+               @|bold Author  |@| ${domain.author}
             """.trimIndent(),
             "\n@|yellow,bold Tables in this domain|@\n"
         )

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
@@ -64,7 +64,7 @@ class ViewDomain(private val service: DomainService) : Runnable {
                     }
                 }
                 else {
-                    val statusText = domainStatus?.let { " and status @|bold $it |@" } ?: ""
+                    val statusText = domainStatus?.let { " and status @|bold $it|@" } ?: ""
                     parent.print("""
                         
                         @|red,bold ERROR|@ - no domain with name '@|bold ${domainName()}|@'$statusText was found

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
@@ -11,13 +11,22 @@ import uk.gov.justice.digital.service.DomainService
 @Singleton
 @Command(
     name = "view",
-    description = ["View details for a specific domain"]
+    description = ["View information for a specific domain"],
+    synopsisHeading = "Usage:\n",
+    customSynopsis = [
+        "   @|bold view -n Domain Name|@",
+        "   @|bold view -n Domain Name -s DRAFT|@",
+        "Examples:",
+        "   View information for the domain 'Example Domain'",
+        "   @|cyan view -n Example Domain|@",
+        "   View information for the domain 'Example Domain' with the status PUBLISHED",
+        "   @|cyan view -n Example Domain -s PUBLISHED|@",
+    ]
 )
 class ViewDomain(private val service: DomainService) : Runnable {
 
     @Option(
         names = ["-h", "--help"],
-        usageHelp = true,
         description = [ "display this help message" ]
     )
     var usageHelpRequested = false
@@ -36,7 +45,7 @@ class ViewDomain(private val service: DomainService) : Runnable {
     @Option(
         names = ["-s", "--status"],
         description = [
-            "the status of the domain to view"
+            "the status of the domain to view, either DRAFT or PUBLISHED"
         ],
         arity = "1",
         required = false,

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.DomainBuilder
 import uk.gov.justice.digital.command.ExceptionHandler.runAndHandleExceptions
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.service.DomainService
+import java.util.*
 
 @Singleton
 @Command(
@@ -23,6 +24,7 @@ class ViewDomain(private val service: DomainService) : Runnable {
     )
     var usageHelpRequested = false
 
+    // TODO - we need a status too
     @Option(
         names = ["-n", "--name"],
         description = [
@@ -58,9 +60,10 @@ class ViewDomain(private val service: DomainService) : Runnable {
             "\n@|green,bold Found domain with name: '${domainName()}'|@\n",
             """
                @|bold Name        |@| ${domain.name} 
+               @|bold Status      |@| ${domain.status.name.lowercase()}
                @|bold Description |@| ${domain.description}
                @|bold Owner       |@| ${domain.owner}
-               @|bold Author  |@| ${domain.author}
+               @|bold Author      |@| ${domain.author}
             """.trimIndent(),
             "\n@|yellow,bold Tables in this domain|@\n"
         )

--- a/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/command/ViewDomain.kt
@@ -1,14 +1,11 @@
 package uk.gov.justice.digital.command
 
 import jakarta.inject.Singleton
-import picocli.CommandLine.Command
-import picocli.CommandLine.Option
-import picocli.CommandLine.ParentCommand
+import picocli.CommandLine.*
 import uk.gov.justice.digital.DomainBuilder
 import uk.gov.justice.digital.command.ExceptionHandler.runAndHandleExceptions
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.service.DomainService
-import java.util.*
 
 @Singleton
 @Command(

--- a/cli/src/main/kotlin/uk/gov/justice/digital/service/DomainService.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/service/DomainService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.service
 import jakarta.inject.Singleton
 import uk.gov.justice.digital.client.DomainClient
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Status
 
 /**
  * Service that wraps calls to the BlockingDomainClient which is responsible for interacting with the backend REST API.
@@ -11,9 +12,6 @@ import uk.gov.justice.digital.model.Domain
  */
 @Singleton
 class DomainService(private val client: DomainClient) {
-
-    fun getAllDomains(): List<Domain> = client.getDomains().toList()
-
-    fun getDomainWithName(name: String): Domain? = client.getDomainWithName(name)
-
+    fun getAllDomains(): Array<Domain> = client.getDomains()
+    fun getDomains(name: String, status: Status? = null): Array<Domain> = client.getDomains(name, status)
 }

--- a/cli/src/test/kotlin/uk/gov/justice/digital/client/BlockingDomainClientTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/client/BlockingDomainClientTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.test.Fixtures
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domains
 
@@ -48,7 +49,7 @@ class BlockingDomainClientTest {
     fun `getDomains should return a domain given a name that exists`() {
         val server = createServerForScenario(Scenarios.HAPPY_PATH)
         val underTest = server.applicationContext.createBean(BlockingDomainClient::class.java)
-        val result = underTest.getDomains("some-name")
+        val result = underTest.getDomains("someone")
         assertEquals(1, result.size)
         assertEquals(domain1, result[0])
     }
@@ -57,19 +58,17 @@ class BlockingDomainClientTest {
     @Requires(property = TEST_SCENARIO, value = Scenarios.HAPPY_PATH)
     @Controller
     class HappyPathController {
-        @Get("/domain")
-        fun getAllDomains(): List<Domain> = domains
-        @Get("/domain?name")
-        fun getDomains(@Suppress("UNUSED_PARAMETER") name: String): Array<Domain> = arrayOf(domain1)
+        @Get("/domain{?name}")
+        fun getDomains(name: String?): Array<Domain> =
+            if (name.isNullOrEmpty()) domains.toTypedArray()
+            else arrayOf(domain1)
     }
 
     @Requires(property = TEST_SCENARIO, value = Scenarios.NO_DATA)
-    @Controller
+    @Controller()
     class NoDataController {
-        @Get("/domain")
-        fun getAllDomains(): List<Domain> = emptyList()
-        @Get("/domain?name")
-        fun getDomains(@Suppress("UNUSED_PARAMETER") name: String): Domain? = null
+        @Get("/domain{?name}")
+        fun getDomains(@Suppress("UNUSED_PARAMETER") name: String?): Array<Domain> = emptyArray()
     }
 
     private fun createServerForScenario(scenario: String): EmbeddedServer {

--- a/cli/src/test/kotlin/uk/gov/justice/digital/command/ListDomainsTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/command/ListDomainsTest.kt
@@ -25,7 +25,7 @@ class ListDomainsTest {
         underTest.parent = mockDomainBuilder
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.getAllDomains() } answers { listOf(domain1, domain2, domain3) }
+        every { mockDomainService.getAllDomains() } answers { arrayOf(domain1, domain2, domain3) }
 
         underTest.run()
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/command/ListDomainsTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/command/ListDomainsTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.command
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.DomainBuilder
+import uk.gov.justice.digital.service.DomainService
+import uk.gov.justice.digital.test.Fixtures.domain1
+import uk.gov.justice.digital.test.Fixtures.domain2
+import uk.gov.justice.digital.test.Fixtures.domain3
+
+class ListDomainsTest {
+
+    private val mockDomainService: DomainService = mockk()
+    private val mockDomainBuilder: DomainBuilder = mockk()
+
+    private val underTest = ListDomains(mockDomainService)
+
+    @Test
+    fun listDomainsGeneratesExpectedOutput() {
+
+        val capturedOutput = mutableListOf<String>()
+
+        underTest.parent = mockDomainBuilder
+
+        every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+        every { mockDomainService.getAllDomains() } answers { listOf(domain1, domain2, domain3) }
+
+        underTest.run()
+
+        assertEquals(expectedOutput, capturedOutput.joinToString(""))
+    }
+}
+
+val expectedOutput = """
+    
+    @|bold,green Found 3 domains|@
+    
+    +----------+--------+--------------------+
+    | @|bold Name    |@ | @|bold Status|@ | @|bold Description       |@ |
+    +----------+--------+--------------------+
+    | Domain 1 | DRAFT  | A domain           |
+    | Domain 2 | DRAFT  | Another domain     |
+    | Domain 3 | DRAFT  | Yet another domain |
+    +----------+--------+--------------------+
+    
+""".trimIndent()

--- a/cli/src/test/kotlin/uk/gov/justice/digital/command/ListDomainsTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/command/ListDomainsTest.kt
@@ -29,20 +29,20 @@ class ListDomainsTest {
 
         underTest.run()
 
+        val expectedOutput = """
+    
+            @|bold,green Found 3 domains|@
+            
+            +----------+--------+--------------------+
+            | @|bold Name    |@ | @|bold Status|@ | @|bold Description       |@ |
+            +----------+--------+--------------------+
+            | Domain 1 | DRAFT  | A domain           |
+            | Domain 2 | DRAFT  | Another domain     |
+            | Domain 3 | DRAFT  | Yet another domain |
+            +----------+--------+--------------------+
+    
+""".trimIndent()
+
         assertEquals(expectedOutput, capturedOutput.joinToString(""))
     }
 }
-
-val expectedOutput = """
-    
-    @|bold,green Found 3 domains|@
-    
-    +----------+--------+--------------------+
-    | @|bold Name    |@ | @|bold Status|@ | @|bold Description       |@ |
-    +----------+--------+--------------------+
-    | Domain 1 | DRAFT  | A domain           |
-    | Domain 2 | DRAFT  | Another domain     |
-    | Domain 3 | DRAFT  | Yet another domain |
-    +----------+--------+--------------------+
-    
-""".trimIndent()

--- a/cli/src/test/kotlin/uk/gov/justice/digital/command/ViewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/command/ViewDomainTest.kt
@@ -16,7 +16,7 @@ class ViewDomainTest {
     private val underTest = ViewDomain(mockDomainService)
 
     @Test
-    fun viewDomainGeneratesExpectedOutput() {
+    fun `view domain displays an existing domain correctly`() {
 
         val capturedOutput = mutableListOf<String>()
 
@@ -44,6 +44,29 @@ class ViewDomainTest {
             @|bold Description |@| A table containing some data
             @|bold Sources     |@| source.table
             @|bold Query       |@| SELECT source.table.field1, source.table.field2 FROM source.table
+            
+            
+        """.trimIndent()
+
+        assertEquals(expectedOutput, capturedOutput.joinToString(""))
+    }
+
+    @Test
+    fun `view domain displays an error message if no domain is found`() {
+
+        val capturedOutput = mutableListOf<String>()
+
+        underTest.parent = mockDomainBuilder
+        underTest.domainNameElements = arrayOf("Domain 1")
+
+        every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+        every { mockDomainService.getDomainWithName(any()) } answers { null }
+
+        underTest.run()
+
+        val expectedOutput = """
+            
+            @|red,bold ERROR|@ - no domain with name '@|bold Domain 1|@' was found
             
             
         """.trimIndent()

--- a/cli/src/test/kotlin/uk/gov/justice/digital/command/ViewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/command/ViewDomainTest.kt
@@ -24,14 +24,16 @@ class ViewDomainTest {
         underTest.domainNameElements = arrayOf("Domain 1")
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.getDomainWithName(any()) } answers { domain1 }
+        every { mockDomainService.getDomains(any(), any()) } answers { arrayOf(domain1) }
 
         underTest.run()
 
         val expectedOutput = """
             
-            @|green,bold Found domain with name: 'Domain 1'|@
+            @|green,bold Found 1 domain with name: 'Domain 1'|@
 
+            @|cyan,bold Domain 'Domain 1' with status DRAFT|@
+            
             @|bold Name        |@| Domain 1 
             @|bold Status      |@| draft
             @|bold Description |@| A domain
@@ -60,7 +62,7 @@ class ViewDomainTest {
         underTest.domainNameElements = arrayOf("Domain 1")
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.getDomainWithName(any()) } answers { null }
+        every { mockDomainService.getDomains(any(), any()) } answers { emptyArray() }
 
         underTest.run()
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/command/ViewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/command/ViewDomainTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.command
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.DomainBuilder
+import uk.gov.justice.digital.service.DomainService
+import uk.gov.justice.digital.test.Fixtures.domain1
+
+class ViewDomainTest {
+
+    private val mockDomainService: DomainService = mockk()
+    private val mockDomainBuilder: DomainBuilder = mockk()
+
+    private val underTest = ViewDomain(mockDomainService)
+
+    @Test
+    fun viewDomainGeneratesExpectedOutput() {
+
+        val capturedOutput = mutableListOf<String>()
+
+        underTest.parent = mockDomainBuilder
+        underTest.domainNameElements = arrayOf("Domain 1")
+
+        every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+        every { mockDomainService.getDomainWithName(any()) } answers { domain1 }
+
+        underTest.run()
+
+        val expectedOutput = """
+            
+            @|green,bold Found domain with name: 'Domain 1'|@
+
+            @|bold Name        |@| Domain 1 
+            @|bold Status      |@| draft
+            @|bold Description |@| A domain
+            @|bold Owner       |@| someone@example.com
+            @|bold Author      |@| someone@example.com
+
+            @|yellow,bold Tables in this domain|@
+
+            @|bold Table       |@| Table 1
+            @|bold Description |@| A table containing some data
+            @|bold Sources     |@| source.table
+            @|bold Query       |@| SELECT source.table.field1, source.table.field2 FROM source.table
+            
+            
+        """.trimIndent()
+
+        assertEquals(expectedOutput, capturedOutput.joinToString(""))
+
+    }
+}

--- a/cli/src/test/kotlin/uk/gov/justice/digital/service/DomainServiceTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/service/DomainServiceTest.kt
@@ -6,8 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import jakarta.inject.Inject
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.client.DomainClient
 import uk.gov.justice.digital.test.Fixtures.domain1
@@ -32,19 +31,20 @@ class DomainServiceTest {
     }
 
     @Test
-    fun `getDomainWithName should return a Domain given a name that exists`() {
-        every { mockDomainClient.getDomainWithName(any()) } returns domain1
+    fun `getDomains should return a Domain given a name that exists`() {
+        every { mockDomainClient.getDomains(any(), any()) } returns arrayOf(domain1)
 
         val name = "Domain 1"
-        val result = underTest.getDomainWithName(name)
+        val result = underTest.getDomains(name)
 
-        assertEquals(name, result?.name)
+        assertEquals(1, result.size)
+        assertEquals(name, result[0].name)
     }
 
     @Test
-    fun `getDomainWithName should return null given a name that does not exist`() {
-        every { mockDomainClient.getDomainWithName(any()) } returns null
-        assertNull(underTest.getDomainWithName("This is not a valid domain name"))
+    fun `getDomains should return null given a name that does not exist`() {
+        every { mockDomainClient.getDomains(any(), any()) } returns emptyArray()
+        assertTrue(underTest.getDomains("This is not a valid domain name").isEmpty())
     }
 
 }

--- a/common/src/main/kotlin/uk/gov/justice/digital/headers/HeaderDefinitions.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/headers/HeaderDefinitions.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.headers
+
+import java.util.*
+
+interface Header {
+    val name: String
+    val value: String
+}
+
+// Trace ID header. Set on each outgoing request. Should be echoed back in server response.
+class TraceIdHeader(override val value: String = UUID.randomUUID().toString()): Header {
+    override val name = "x-dpr-trace-id"
+}
+
+// Session ID header. Should be constant for the duration of a session. Should be echoed back in server response.
+class SessionIdHeader(override val value: String = UUID.randomUUID().toString()): Header {
+    override val name = "x-dpr-session-id"
+}

--- a/common/src/main/kotlin/uk/gov/justice/digital/model/Domain.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/model/Domain.kt
@@ -2,19 +2,24 @@ package uk.gov.justice.digital.model
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.micronaut.serde.annotation.Serdeable
+import java.time.Instant
 import java.util.*
 
 @Serdeable
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Domain(
-    val id: UUID,
-    val name: String,
-    val description: String,
-    val version: String,
-    val location: String,
-    val tags: Map<String, String> = emptyMap(),
-    val owner: String,
-    val author: String,
-    val originator: String,
-    val tables: List<Table> = emptyList(),
+        val id: UUID,
+        val name: String,
+        val description: String,
+        val version: String,
+        val location: String,
+        val tags: Map<String, String> = emptyMap(),
+        val owner: String,
+        val author: String,
+        val tables: List<Table> = emptyList(),
+        // The following fields are domain builder specific and can be omitted from the published domain.
+        val status: Status = Status.DRAFT,
+        // If the caller does not set the timestamps the repository will take care of them.
+        val created: Instant? = null,
+        val lastUpdated: Instant? = null,
 )

--- a/common/src/main/kotlin/uk/gov/justice/digital/model/Status.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/model/Status.kt
@@ -3,7 +3,5 @@ package uk.gov.justice.digital.model
 // TODO - set this on domain
 enum class Status {
     DRAFT,
-    IN_REVIEW,
-    REVIEWED,
     PUBLISHED
 }

--- a/common/src/main/kotlin/uk/gov/justice/digital/model/Status.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/model/Status.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.model
+
+// TODO - set this on domain
+enum class Status {
+    DRAFT,
+    IN_REVIEW,
+    REVIEWED,
+    PUBLISHED
+}

--- a/common/src/main/kotlin/uk/gov/justice/digital/model/Status.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/model/Status.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.model
 
-// TODO - set this on domain
 enum class Status {
     DRAFT,
     PUBLISHED

--- a/common/src/main/kotlin/uk/gov/justice/digital/time/ClockProvider.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/time/ClockProvider.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.time
+
+import jakarta.inject.Singleton
+import java.time.Clock
+
+interface ClockProvider {
+    val clock: Clock
+}
+
+@Singleton
+class DefaultClockProvider : ClockProvider {
+    override val clock: Clock = Clock.systemUTC()
+}

--- a/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
+++ b/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.test
 
 import uk.gov.justice.digital.model.Domain
+import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.model.Table
 import uk.gov.justice.digital.model.Transform
 import java.util.*
@@ -48,14 +49,19 @@ object Fixtures {
     val domain1 = Domain(
         id = UUID.randomUUID(),
         name = "Domain 1",
+        status = Status.DRAFT,
         description = "A domain",
         version = "0.0.1",
         location = "/domain1",
         tags = tags,
         owner = EMAIL,
         author = EMAIL,
-        originator = EMAIL,
         tables = listOf(table1),
+    )
+
+    val publishedDomain1 = domain1.copy(
+        id = UUID.randomUUID(),
+        status = Status.PUBLISHED
     )
 
     val domain2 = domain1.copy(

--- a/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/time/FixedClock.kt
+++ b/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/time/FixedClock.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.test.time
+
+import uk.gov.justice.digital.time.ClockProvider
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset.UTC
+
+// Fixed clock for stable tests that involve temporal values.
+class FixedClock : ClockProvider {
+    override val clock: Clock = Clock.fixed(Instant.parse("2023-01-01T00:00:00Z"), UTC)
+}

--- a/docker/start-postgres
+++ b/docker/start-postgres
@@ -4,7 +4,7 @@
 # Checks that the required commands are installed and will attempt to start the
 # docker daemon if it's not running.
 #
-# Supports either Docker Destop (MAC) or colima, a cli only alterantive.
+# Supports either Docker Destop (MAC) or colima, a cli only alternative.
 #
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/docker/templates/domain-template.json
+++ b/docker/templates/domain-template.json
@@ -6,7 +6,7 @@
   "location": "/incident",
   "name": "DOMAIN_NAME",
   "owner": "michael.w.clarke@justice.gov.uk",
-  "originator": "michael.w.clarke@justice.gov.uk",
+  "state": "DRAFT",
   "tables": [
     {
       "_comment": "DPR-128 Incident Table",


### PR DESCRIPTION
Summary of changes
* introduced status field and revised the unique constraint to allow a domain to exist in multiple states (name and status now form a unique id)
* updated the backend code to support the status field and allow retrieval of domains by name and/or status
* updated the cli frontend to show the status value and allow a domain to be retrieved by name and status
  * in the case where only the name is specified and more than one state is stored, the frontend will retrieve and show data for each state
* introduced `ClockProvider` allowing a fixed clock to be used in tests for deterministic behaviour
* added tests for the individual commands that compare the generated output against a string of the expected output
