### PR TITLE
DPR-513 enable aggregate test coverage report

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
 
 application {
   // For local testing only.
-  mainClass.set("uk.gov.justice.digital.DomainBuilderBackend")
+  mainClass.set("uk.gov.justice.digital.backend.DomainBuilderBackend")
 }
 
 // Task specific configuration.

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/DomainBuilderBackend.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/DomainBuilderBackend.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital
+package uk.gov.justice.digital.backend
 
 import io.micronaut.runtime.Micronaut
 

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/MigrationRunner.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/MigrationRunner.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital
+package uk.gov.justice.digital.backend
 
 import io.micronaut.configuration.picocli.PicocliRunner
 import jakarta.inject.Singleton

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
@@ -1,11 +1,11 @@
-package uk.gov.justice.digital.controller
+package uk.gov.justice.digital.backend.controller
 
 import io.micronaut.http.MediaType.APPLICATION_JSON
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
-import uk.gov.justice.digital.service.DomainService
+import uk.gov.justice.digital.backend.service.DomainService
 import java.util.*
 
 @Controller("/domain")

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/filter/RequestResponseLogger.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/filter/RequestResponseLogger.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.filter
+package uk.gov.justice.digital.backend.filter
 
 import io.micronaut.core.async.publisher.Publishers
 import io.micronaut.http.HttpRequest

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/repository/DomainRepository.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/repository/DomainRepository.kt
@@ -1,11 +1,11 @@
-package uk.gov.justice.digital.repository
+package uk.gov.justice.digital.backend.repository
 
 import jakarta.inject.Singleton
 import org.ktorm.database.Database
 import org.ktorm.dsl.*
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
-import uk.gov.justice.digital.repository.table.DomainTable
+import uk.gov.justice.digital.backend.repository.table.DomainTable
 import uk.gov.justice.digital.time.ClockProvider
 import java.util.*
 import javax.sql.DataSource

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/repository/table/DomainTable.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/repository/table/DomainTable.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.repository.table
+package uk.gov.justice.digital.backend.repository.table
 
 import org.ktorm.jackson.json
 import org.ktorm.schema.*

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainService.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainService.kt
@@ -1,9 +1,9 @@
-package uk.gov.justice.digital.service
+package uk.gov.justice.digital.backend.service
 
 import jakarta.inject.Singleton
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
-import uk.gov.justice.digital.repository.DomainRepository
+import uk.gov.justice.digital.backend.repository.DomainRepository
 import java.util.*
 
 interface DomainService {

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/DomainControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/DomainControllerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.controller
+package uk.gov.justice.digital.backend.controller
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
-import uk.gov.justice.digital.service.DomainService
+import uk.gov.justice.digital.backend.service.DomainService
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domains
 import java.util.*

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/repository/DomainRepositoryTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/repository/DomainRepositoryTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.repository
+package uk.gov.justice.digital.backend.repository
 
 import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.Assertions.*
@@ -10,6 +10,10 @@ import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import uk.gov.justice.digital.backend.repository.CreateFailedException
+import uk.gov.justice.digital.backend.repository.DeleteFailedException
+import uk.gov.justice.digital.backend.repository.DomainRepository
+import uk.gov.justice.digital.backend.repository.UpdateFailedException
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.test.Fixtures.domain1

--- a/bin/apply-migrations
+++ b/bin/apply-migrations
@@ -53,7 +53,7 @@ function apply_migrations {
   log_file="/tmp/migration-log-$(date +'%Y-%m-%dT%H:%M:%S').log"
   show_info "Launching $jar_path"
   show_wait "Applying migrations..."
-  if run_with_local_postgres_config java -cp $jar_path uk.gov.justice.digital.MigrationRunner &> $log_file
+  if run_with_local_postgres_config java -cp $jar_path uk.gov.justice.digital.backend.MigrationRunner &> $log_file
   then
     show_ok "Migrations applied successfully"
   else

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   jacoco
   id("org.sonarqube") version "3.5.0.2730"
   id("org.owasp.dependencycheck") version "8.2.1"
+  id("jacoco-report-aggregation")
 }
 
 repositories {
@@ -38,3 +39,12 @@ subprojects {
   }
 }
 
+tasks.check {
+    dependsOn(tasks.named<JacocoReport>("testCodeCoverageReport"))
+}
+
+dependencies {
+  implementation(project(":common"))
+  implementation(project(":backend"))
+  implementation(project(":cli"))
+}

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
 
 
 application {
-  mainClass.set("uk.gov.justice.digital.DomainBuilder")
+  mainClass.set("uk.gov.justice.digital.cli.DomainBuilder")
 }
 
 tasks {

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/DomainBuilder.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/DomainBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital
+package uk.gov.justice.digital.cli
 
 import io.micronaut.configuration.picocli.MicronautFactory
 import io.micronaut.configuration.picocli.PicocliRunner
@@ -6,10 +6,10 @@ import jakarta.inject.Singleton
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
-import uk.gov.justice.digital.command.ListDomains
-import uk.gov.justice.digital.command.ViewDomain
-import uk.gov.justice.digital.session.BatchSession
-import uk.gov.justice.digital.session.InteractiveSession
+import uk.gov.justice.digital.cli.command.ListDomains
+import uk.gov.justice.digital.cli.command.ViewDomain
+import uk.gov.justice.digital.cli.session.BatchSession
+import uk.gov.justice.digital.cli.session.InteractiveSession
 
 @Command(
     name = "domain-builder",

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.client
+package uk.gov.justice.digital.cli.client
 
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Value

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ExceptionHandler.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ExceptionHandler.kt
@@ -1,6 +1,6 @@
-package uk.gov.justice.digital.command
+package uk.gov.justice.digital.cli.command
 
-import uk.gov.justice.digital.DomainBuilder
+import uk.gov.justice.digital.cli.DomainBuilder
 
 object ExceptionHandler {
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
@@ -1,11 +1,11 @@
-package uk.gov.justice.digital.command
+package uk.gov.justice.digital.cli.command
 
 import jakarta.inject.Singleton
 import picocli.CommandLine.*
-import uk.gov.justice.digital.DomainBuilder
-import uk.gov.justice.digital.command.ExceptionHandler.runAndHandleExceptions
+import uk.gov.justice.digital.cli.DomainBuilder
+import uk.gov.justice.digital.cli.command.ExceptionHandler.runAndHandleExceptions
 import uk.gov.justice.digital.model.Domain
-import uk.gov.justice.digital.service.DomainService
+import uk.gov.justice.digital.cli.service.DomainService
 
 @Singleton
 @Command(

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ViewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ViewDomain.kt
@@ -1,12 +1,12 @@
-package uk.gov.justice.digital.command
+package uk.gov.justice.digital.cli.command
 
 import jakarta.inject.Singleton
 import picocli.CommandLine.*
-import uk.gov.justice.digital.DomainBuilder
-import uk.gov.justice.digital.command.ExceptionHandler.runAndHandleExceptions
+import uk.gov.justice.digital.cli.DomainBuilder
+import uk.gov.justice.digital.cli.command.ExceptionHandler.runAndHandleExceptions
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
-import uk.gov.justice.digital.service.DomainService
+import uk.gov.justice.digital.cli.service.DomainService
 
 @Singleton
 @Command(

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
@@ -1,7 +1,7 @@
-package uk.gov.justice.digital.service
+package uk.gov.justice.digital.cli.service
 
 import jakarta.inject.Singleton
-import uk.gov.justice.digital.client.DomainClient
+import uk.gov.justice.digital.cli.client.DomainClient
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.session
+package uk.gov.justice.digital.cli.session
 
 import jakarta.inject.Singleton
 import org.fusesource.jansi.AnsiConsole

--- a/cli/src/test/kotlin/uk/gov/justice/digital/client/BlockingDomainClientTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/client/BlockingDomainClientTest.kt
@@ -9,6 +9,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import uk.gov.justice.digital.cli.client.BlockingDomainClient
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.test.Fixtures.domain1

--- a/cli/src/test/kotlin/uk/gov/justice/digital/command/ListDomainsTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/command/ListDomainsTest.kt
@@ -4,8 +4,9 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.DomainBuilder
-import uk.gov.justice.digital.service.DomainService
+import uk.gov.justice.digital.cli.DomainBuilder
+import uk.gov.justice.digital.cli.command.ListDomains
+import uk.gov.justice.digital.cli.service.DomainService
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domain2
 import uk.gov.justice.digital.test.Fixtures.domain3

--- a/cli/src/test/kotlin/uk/gov/justice/digital/command/ViewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/command/ViewDomainTest.kt
@@ -4,8 +4,9 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.DomainBuilder
-import uk.gov.justice.digital.service.DomainService
+import uk.gov.justice.digital.cli.DomainBuilder
+import uk.gov.justice.digital.cli.command.ViewDomain
+import uk.gov.justice.digital.cli.service.DomainService
 import uk.gov.justice.digital.test.Fixtures.domain1
 
 class ViewDomainTest {

--- a/cli/src/test/kotlin/uk/gov/justice/digital/service/DomainServiceTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/service/DomainServiceTest.kt
@@ -8,7 +8,8 @@ import io.mockk.verify
 import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.client.DomainClient
+import uk.gov.justice.digital.cli.service.DomainService
+import uk.gov.justice.digital.cli.client.DomainClient
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domains
 


### PR DESCRIPTION
Summary of changes
* introduce `backend` and `cli` packages to ensure classes with the same name don't collide when generating a coverage report
* revised top level build enabling the aggregate jacoco report plugin
* updated scripts to reference the new packages where necessary