### PR TITLE
DPR-409 backend API create domain endpoint

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -75,17 +75,10 @@ application {
   mainClass.set("uk.gov.justice.digital.backend.DomainBuilderBackend")
 }
 
-// Task specific configuration.
 tasks {
 
   named<Test>("test") {
     useJUnitPlatform()
-  }
-
-  // TODO - temporary fudge for the sync script which expects both jars to be present
-  named<Jar>("jar") {
-    archiveBaseName.set("domain-builder-backend-api")
-    destinationDirectory.set(File("${project.rootDir}/build/libs"))
   }
 
   named<ShadowJar>("shadowJar") {

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
@@ -28,8 +28,8 @@ class DomainController(private val service: DomainService) {
 
     @Post(consumes = [APPLICATION_JSON])
     fun createDomain(domain: WriteableDomain): HttpResponse<Unit>? {
-        // TODO - set header correctly.
-        return HttpResponse.created(URI.create("/domain/some-uuid"));
+        val domainId = service.createDomain(domain)
+        return HttpResponse.created(URI.create("/domain/$domainId"));
     }
 
 }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
@@ -4,8 +4,10 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus.*
 import io.micronaut.http.MediaType.APPLICATION_JSON
 import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Error
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
+import uk.gov.justice.digital.backend.repository.DuplicateKeyException
 import uk.gov.justice.digital.backend.service.DomainService
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
@@ -30,6 +32,11 @@ class DomainController(private val service: DomainService) {
     fun createDomain(domain: WriteableDomain): HttpResponse<Unit>? {
         val domainId = service.createDomain(domain)
         return HttpResponse.created(URI.create("/domain/$domainId"));
+    }
+
+    @Error(exception = DuplicateKeyException::class)
+    fun duplicateKeyErrorHandler(): HttpResponse<Unit> {
+        return HttpResponse.status(CONFLICT)
     }
 
 }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
@@ -1,16 +1,16 @@
 package uk.gov.justice.digital.backend.controller
 
-import io.micronaut.http.HttpStatus
+import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus.*
 import io.micronaut.http.MediaType.APPLICATION_JSON
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Status as ResponseStatus
-import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.backend.service.DomainService
+import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.model.WriteableDomain
+import java.net.URI
 import java.util.*
 
 @Controller("/domain")
@@ -26,10 +26,10 @@ class DomainController(private val service: DomainService) {
         return service.getDomain(id)
     }
 
-    @ResponseStatus(CREATED)
     @Post(consumes = [APPLICATION_JSON])
-    fun createDomain(domain: WriteableDomain) {
-        println("Got domain: $domain")
+    fun createDomain(domain: WriteableDomain): HttpResponse<Unit>? {
+        // TODO - set header correctly.
+        return HttpResponse.created(URI.create("/domain/some-uuid"));
     }
 
 }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
@@ -1,11 +1,16 @@
 package uk.gov.justice.digital.backend.controller
 
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.HttpStatus.*
 import io.micronaut.http.MediaType.APPLICATION_JSON
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Status as ResponseStatus
 import uk.gov.justice.digital.model.Domain
-import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.backend.service.DomainService
+import uk.gov.justice.digital.model.Status
+import uk.gov.justice.digital.model.WriteableDomain
 import java.util.*
 
 @Controller("/domain")
@@ -19,6 +24,12 @@ class DomainController(private val service: DomainService) {
     @Get("/{id}", produces = [APPLICATION_JSON])
     fun getDomain(id: UUID): Domain? {
         return service.getDomain(id)
+    }
+
+    @ResponseStatus(CREATED)
+    @Post(consumes = [APPLICATION_JSON])
+    fun createDomain(domain: WriteableDomain) {
+        println("Got domain: $domain")
     }
 
 }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainService.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainService.kt
@@ -4,21 +4,25 @@ import jakarta.inject.Singleton
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.backend.repository.DomainRepository
+import uk.gov.justice.digital.model.WriteableDomain
 import java.util.*
 
 interface DomainService {
     fun getDomains(name: String? = null, status: Status? = null): List<Domain>
     fun getDomain(id: UUID): Domain?
+    fun createDomain(domain: WriteableDomain): UUID
 }
 
 /**
  * Service that will handle calls to the backend database.
  *
- * For now this just supports the retrieval of domains but will be extended in future work to cover creation,
- * updating and deletion.
+ * Supports creation and retrieval of domains delegating to the repository.
+ *
+ * Update and delete to follow in later work.
  */
 @Singleton
 class RepositoryBackedDomainService(private val repository: DomainRepository): DomainService {
     override fun getDomains(name: String?, status: Status?): List<Domain> = repository.getDomains(name)
     override fun getDomain(id: UUID): Domain? = repository.getDomain(id)
+    override fun createDomain(domain: WriteableDomain): UUID = repository.createDomain(domain)
 }

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/DomainControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/DomainControllerTest.kt
@@ -18,6 +18,7 @@ import io.mockk.verify
 import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.backend.repository.DuplicateKeyException
 import uk.gov.justice.digital.backend.service.DomainService
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
@@ -186,6 +187,18 @@ class DomainControllerTest {
     fun `POST of an invalid domain should return a HTTP 400`() {
         val responseException = assertThrows(HttpClientResponseException::class.java) { post("/domain", "{}") }
         assertEquals(BAD_REQUEST, responseException.status)
+    }
+
+    @Test
+    fun `POST of duplicate domain returns HTTP 409`() {
+
+        every { mockDomainService.createDomain(any()) } throws DuplicateKeyException("Duplicate key error", RuntimeException())
+
+        val responseException = assertThrows(HttpClientResponseException::class.java) {
+            post("/domain", jacksonObjectMapper().writeValueAsString(writeableDomain))
+        }
+
+        assertEquals(CONFLICT, responseException.status)
     }
 
     private fun get(location: String): HttpResponse<String> =

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/DomainControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/DomainControllerTest.kt
@@ -173,9 +173,13 @@ class DomainControllerTest {
 
     @Test
     fun `POST of a valid domain should return a HTTP 201 with a location header pointing to the created resource`() {
+        val uuid = UUID.randomUUID()
+        every { mockDomainService.createDomain(any()) } returns uuid
+
         val response = post("/domain", jacksonObjectMapper().writeValueAsString(writeableDomain))
+
         assertEquals(CREATED, response.status)
-        assertEquals("/domain/some-uuid", response.header("Location"))
+        assertEquals("/domain/$uuid", response.header("Location"))
     }
 
     @Test

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/repository/DomainRepositoryTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/repository/DomainRepositoryTest.kt
@@ -94,9 +94,9 @@ class DomainRepositoryTest {
     }
 
     @Test
-    fun `createDomain should throw an exception for a failed insert`() {
+    fun `createDomain should throw a DuplicateKeyException for attempt to insert duplicate Domain`() {
         underTest.createDomain(domain1)
-        assertThrows(CreateFailedException::class.java) {
+        assertThrows(DuplicateKeyException::class.java) {
             // This second insert attempt should fail since we're trying to insert a duplicate
             underTest.createDomain(domain1)
         }
@@ -134,10 +134,10 @@ class DomainRepositoryTest {
     }
 
     @Test
-    fun `createDomain should reject second attempt to insert a writeable domain that has already been inserted`() {
+    fun `createDomain should throw a DuplicateKeyException for attempt to insert duplicate WriteableDomain`() {
         underTest.createDomain(writeableDomain)
 
-        assertThrows(CreateFailedException::class.java) {
+        assertThrows(DuplicateKeyException::class.java) {
             // This second insert attempt should fail the unique constraint on name and status since we already have
             // a record with the same name and status.
             underTest.createDomain(writeableDomain)

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/repository/DomainRepositoryTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/repository/DomainRepositoryTest.kt
@@ -10,10 +10,6 @@ import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import uk.gov.justice.digital.backend.repository.CreateFailedException
-import uk.gov.justice.digital.backend.repository.DeleteFailedException
-import uk.gov.justice.digital.backend.repository.DomainRepository
-import uk.gov.justice.digital.backend.repository.UpdateFailedException
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.test.Fixtures.domain1
@@ -21,6 +17,7 @@ import uk.gov.justice.digital.test.Fixtures.domain2
 import uk.gov.justice.digital.test.Fixtures.domain3
 import uk.gov.justice.digital.test.Fixtures.domains
 import uk.gov.justice.digital.test.Fixtures.publishedDomain1
+import uk.gov.justice.digital.test.Fixtures.writeableDomain
 import uk.gov.justice.digital.test.time.FixedClock
 import java.time.Instant
 import java.util.*
@@ -78,8 +75,9 @@ class DomainRepositoryTest {
 
     @Test
     fun `createDomain should set timestamps where none are provided`() {
-        underTest.createDomain(domain1)
-        val retrievedDomain = underTest.getDomain(domain1.id)
+        val domainId = underTest.createDomain(domain1)
+        val retrievedDomain = underTest.getDomain(domainId)
+        assertEquals(retrievedDomain?.id, domainId)
         assertEquals(fixedClock.instant(), retrievedDomain?.created)
         assertEquals(fixedClock.instant(), retrievedDomain?.lastUpdated)
     }
@@ -91,8 +89,8 @@ class DomainRepositoryTest {
                 created = ts,
                 lastUpdated = ts,
         )
-        underTest.createDomain(domainWithTimestamps)
-        assertEquals(domainWithTimestamps, underTest.getDomain(domainWithTimestamps.id))
+        val domainId = underTest.createDomain(domainWithTimestamps)
+        assertEquals(domainWithTimestamps, underTest.getDomain(domainId))
     }
 
     @Test
@@ -110,6 +108,39 @@ class DomainRepositoryTest {
         assertDoesNotThrow {
             // This second assert should succeed
             underTest.createDomain(publishedDomain1)
+        }
+    }
+
+    @Test
+    fun `createDomain should create a valid domain from a writeable domain`() {
+        val domainId = underTest.createDomain(writeableDomain)
+        val createdDomain = underTest.getDomain(domainId)
+        // Verify fields that should be set during create
+        assertEquals(domainId, createdDomain?.id)
+        assertEquals(fixedClock.instant(), createdDomain?.created)
+        assertEquals(fixedClock.instant(), createdDomain?.lastUpdated)
+        // Verify that remaining fields are mapped from writeableDomain to Domain correctly.
+        mapOf(
+            writeableDomain.name to createdDomain?.name,
+            writeableDomain.description to createdDomain?.description,
+            writeableDomain.version to createdDomain?.version,
+            writeableDomain.location to createdDomain?.location,
+            writeableDomain.tags to createdDomain?.tags,
+            writeableDomain.owner to createdDomain?.owner,
+            writeableDomain.author to createdDomain?.author,
+            writeableDomain.tables to createdDomain?.tables,
+            writeableDomain.status to createdDomain?.status,
+        ).forEach { (expected, got) -> assertEquals(expected, got) }
+    }
+
+    @Test
+    fun `createDomain should reject second attempt to insert a writeable domain that has already been inserted`() {
+        underTest.createDomain(writeableDomain)
+
+        assertThrows(CreateFailedException::class.java) {
+            // This second insert attempt should fail the unique constraint on name and status since we already have
+            // a record with the same name and status.
+            underTest.createDomain(writeableDomain)
         }
     }
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -65,12 +65,6 @@ tasks {
     standardInput = System.`in`
   }
 
-  // TODO - temporary fudge for the sync script which expects both jars to be present
-  named<Jar>("jar") {
-    archiveBaseName.set("domain-builder-cli-frontend")
-    destinationDirectory.set(File("${project.rootDir}/build/libs"))
-  }
-
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-cli-frontend")
     destinationDirectory.set(File("${project.rootDir}/build/libs"))

--- a/common/src/main/kotlin/uk/gov/justice/digital/model/WriteableDomain.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/model/WriteableDomain.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class WriteableDomain(
+        val name: String,
+        val description: String,
+        val version: String,
+        val location: String,
+        val tags: Map<String, String> = emptyMap(),
+        val owner: String,
+        val author: String,
+        val tables: List<Table> = emptyList(),
+        // The following fields are domain builder specific and can be omitted from the published domain.
+        val status: Status = Status.DRAFT,
+)

--- a/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
+++ b/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.test
 
-import uk.gov.justice.digital.model.Domain
-import uk.gov.justice.digital.model.Status
-import uk.gov.justice.digital.model.Table
-import uk.gov.justice.digital.model.Transform
+import uk.gov.justice.digital.model.*
 import java.util.*
 
 object Fixtures {
@@ -81,5 +78,17 @@ object Fixtures {
     )
 
     val domains = listOf(domain1, domain2, domain3)
+
+    val writeableDomain = WriteableDomain(
+        name = "New Domain 1",
+        status = Status.DRAFT,
+        description = "A new domain",
+        version = "0.0.1",
+        location = "/newDomain1",
+        tags = tags,
+        owner = EMAIL,
+        author = EMAIL,
+        tables = listOf(table1),
+    )
 
 }


### PR DESCRIPTION
Summary of changes
* backend API now supports creation of Domains returning a HTTP 201 with a location header pointing to the newly created domain by ID on success
* a HTTP 400 BAD REQUEST will be returned if the post body is invalid
* a HTTP 409 CONFLICT will be returned on a unique key violation
* revised repository and service layers and updated tests as required
* cleaned up build scripts removing temporary fix that was needed prior to the sync script being fixed