### PR TITLE
DPR-412 cli and backend now use the trace and session IDs

### DIFF
--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/filter/RequestResponseLogger.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/filter/RequestResponseLogger.kt
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory
 @Filter(MATCH_ALL_PATTERN)
 class RequestResponseLogger : HttpServerFilter {
 
-    private val logger = LoggerFactory.getLogger(RequestResponseLogger::class.java)
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     override fun getOrder(): Int = ServerFilterPhase.LAST.after()
 

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/filter/TraceIdFilter.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/filter/TraceIdFilter.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.backend.filter
+
+import io.micronaut.core.async.publisher.Publishers
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.filter.ServerFilterPhase
+import org.reactivestreams.Publisher
+import org.slf4j.MDC
+import uk.gov.justice.digital.headers.Header
+import java.util.*
+
+@Filter(MATCH_ALL_PATTERN)
+class TraceIdFilter : HttpServerFilter {
+
+    override fun getOrder(): Int = ServerFilterPhase.TRACING.after()
+
+    override fun doFilter(request: HttpRequest<*>?, chain: ServerFilterChain?): Publisher<MutableHttpResponse<*>> {
+        val traceId = request?.headers?.get(Header.TRACE_ID_HEADER_NAME) ?: UUID.randomUUID().toString()
+        val sessionId = request?.headers?.get(Header.SESSION_ID_HEADER_NAME)
+        MDC.put(TRACE_ID, traceId)
+        // If we have a session ID then stash this on the MDC too
+        request?.headers?.get(Header.SESSION_ID_HEADER_NAME)?.let { MDC.put(SESSION_ID, it) }
+
+        return Publishers.map(chain?.proceed(request), setResponseHeadersAndClearMdc(traceId, sessionId))
+    }
+
+    private val setResponseHeadersAndClearMdc: (String, String?) -> (MutableHttpResponse<*>) -> MutableHttpResponse<*> =
+        { traceId: String, sessionId: String? ->
+            { response ->
+                // Set the trace and session id headers on the response.
+                response.header(Header.TRACE_ID_HEADER_NAME, traceId)
+                sessionId?.let { response.header(Header.SESSION_ID_HEADER_NAME, it) }
+
+                // Clear the MDC
+                MDC.clear()
+
+                response
+            }
+        }
+
+    companion object {
+        const val TRACE_ID = "traceId"
+        const val SESSION_ID = "sessionId"
+    }
+
+}

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/filter/TraceIdFilter.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/filter/TraceIdFilter.kt
@@ -36,7 +36,8 @@ class TraceIdFilter : HttpServerFilter {
                 sessionId?.let { response.header(Header.SESSION_ID_HEADER_NAME, it) }
 
                 // Clear the MDC
-                MDC.clear()
+                MDC.remove(TRACE_ID)
+                MDC.remove(SESSION_ID)
 
                 response
             }

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-           <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-4level) %logger{36} %thread %msg %mdc %marker%n</pattern>
+           <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-4level) %logger{36} %M %thread %msg %mdc %n</pattern>
        </encoder>
    </appender>
 
@@ -17,6 +17,7 @@
         </encoder>
     </appender>
 
+    <!-- when running locally set to CONSOLE to see MDC values -->
     <root level="INFO">
       <appender-ref ref="CLOUDWATCH" />
     </root>

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/filter/TraceIdFilterTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/filter/TraceIdFilterTest.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.backend.filter
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.backend.service.DomainService
+import uk.gov.justice.digital.headers.Header
+import uk.gov.justice.digital.headers.SessionIdHeader
+import uk.gov.justice.digital.headers.TraceIdHeader
+
+@MicronautTest
+class TraceIdFilterTest {
+
+    @Inject
+    private lateinit var server: EmbeddedServer
+
+    @Inject
+    @field:Client("/")
+    private lateinit var client: HttpClient
+
+    private val mockDomainService: DomainService = mockk()
+
+    @MockBean(DomainService::class)
+    fun getMockDomainService() = mockDomainService
+
+    @Test
+    fun `request with trace and session IDs should result in a response with the same trace headers`() {
+        every { mockDomainService.getDomains(any()) } returns emptyList()
+
+        val traceId = TraceIdHeader()
+        val sessionId = SessionIdHeader()
+
+        val request = HttpRequest.GET<String>("/domain")
+            .header(traceId.name, traceId.value)
+            .header(sessionId.name, sessionId.value)
+
+        val response =
+            client
+                .toBlocking()
+                .exchange(request, String::class.java)
+
+        assertEquals(traceId.value, response.header(traceId.name))
+        assertEquals(sessionId.value, response.header(sessionId.name))
+    }
+
+    @Test
+    fun `request with no trace IDs should result in a response with a traceId header`() {
+        every { mockDomainService.getDomains(any()) } returns emptyList()
+
+        val traceId = TraceIdHeader()
+
+        val request = HttpRequest.GET<String>("/domain")
+            .header(traceId.name, traceId.value)
+
+        val response =
+            client
+                .toBlocking()
+                .exchange(request, String::class.java)
+
+        assertEquals(traceId.value, response.header(traceId.name))
+        assertNull(response.header(Header.SESSION_ID_HEADER_NAME))
+    }
+
+}

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/filter/TraceIdFilterTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/filter/TraceIdFilterTest.kt
@@ -9,13 +9,14 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import io.mockk.every
 import io.mockk.mockk
 import jakarta.inject.Inject
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import uk.gov.justice.digital.backend.service.DomainService
 import uk.gov.justice.digital.headers.Header
 import uk.gov.justice.digital.headers.SessionIdHeader
 import uk.gov.justice.digital.headers.TraceIdHeader
+import java.util.*
 
 @MicronautTest
 class TraceIdFilterTest {
@@ -56,17 +57,15 @@ class TraceIdFilterTest {
     fun `request with no trace IDs should result in a response with a traceId header`() {
         every { mockDomainService.getDomains(any()) } returns emptyList()
 
-        val traceId = TraceIdHeader()
-
         val request = HttpRequest.GET<String>("/domain")
-            .header(traceId.name, traceId.value)
 
         val response =
             client
                 .toBlocking()
                 .exchange(request, String::class.java)
 
-        assertEquals(traceId.value, response.header(traceId.name))
+        assertNotNull(response.header(Header.TRACE_ID_HEADER_NAME))
+        assertDoesNotThrow { UUID.fromString(response.header(Header.TRACE_ID_HEADER_NAME)) }
         assertNull(response.header(Header.SESSION_ID_HEADER_NAME))
     }
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
@@ -10,6 +10,9 @@ import io.micronaut.http.uri.UriBuilder
 import io.micronaut.serde.ObjectMapper
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import uk.gov.justice.digital.headers.Header
+import uk.gov.justice.digital.headers.SessionIdHeader
+import uk.gov.justice.digital.headers.TraceIdHeader
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.model.WriteableDomain
@@ -67,7 +70,11 @@ class BlockingDomainClient : DomainClient {
         HttpRequest.newBuilder(uri)
             .header(ACCEPT, APPLICATION_JSON)
             .header(USER_AGENT, "domain-builder-cli/v0.0.1")
+            .withCustomHeader(TraceIdHeader())
+            .withCustomHeader(SessionIdHeader.instance)
             .timeout(REQUEST_TIMEOUT)
+
+    private fun HttpRequest.Builder.withCustomHeader(header: Header) = this.header(header.name, header.value)
 
     private inline fun <reified T> HttpClient.get(uri: URI): T {
         val request = configuredRequestBuilder(uri)

--- a/common/src/main/kotlin/uk/gov/justice/digital/headers/HeaderDefinitions.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/headers/HeaderDefinitions.kt
@@ -5,14 +5,23 @@ import java.util.*
 interface Header {
     val name: String
     val value: String
+
+    companion object {
+        const val TRACE_ID_HEADER_NAME = "x-dpr-trace-id"
+        const val SESSION_ID_HEADER_NAME = "x-dpr-session-id"
+    }
 }
 
 // Trace ID header. Set on each outgoing request. Should be echoed back in server response.
 class TraceIdHeader(override val value: String = UUID.randomUUID().toString()): Header {
-    override val name = "x-dpr-trace-id"
+    override val name = Header.TRACE_ID_HEADER_NAME
 }
 
 // Session ID header. Should be constant for the duration of a session. Should be echoed back in server response.
 class SessionIdHeader(override val value: String = UUID.randomUUID().toString()): Header {
-    override val name = "x-dpr-session-id"
+    override val name = Header.SESSION_ID_HEADER_NAME
+    companion object {
+        // A single instance available for the duration of a session to be used where a session ID header is required.
+        val instance = SessionIdHeader()
+    }
 }


### PR DESCRIPTION
Summary of changes
* cli frontend now sets a session ID and trace ID header on outbound requests
* in interactive mode the session ID is status for the lifetime of the process allowing requests to be tied to a single user session
* backend now has a filter that stashes the trace ID and session ID (if set) on the MDC so this is propagated to all log messages for the duration of the request
* backend also sets the trace ID and session ID headers on the response so the frontend can surface these values if required
* added tests covering these changes as far as possible
* added logging to the DomainRepository for those methods currently in use (more logging to follow as work progresses)