### PR TITLE
DPR-411 validate spark SQL strings in domain definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           bucket_prefix: dpr-artifact-store
           deploy_to_test: true # Deploy to Test Environment
           deploy_to_preprod: true # Deploy to PreProd Environment
-          cache_key: "v5"
+          cache_key: "v6"
           notify_jira: true
           notify_slack: true
           channel: dpr_cicd_alerts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           bucket_prefix: dpr-artifact-store
           deploy_to_test: true # Deploy to Test Environment
           deploy_to_preprod: true # Deploy to PreProd Environment
-          cache_key: "v6"
+          cache_key: "dpr-domain-builder-build-cache"
           notify_jira: true
           notify_slack: true
           channel: dpr_cicd_alerts
@@ -49,4 +49,4 @@ workflows:
           context:
             - hmpps-reporting-common
             - hmpps-reporting-orb
-          cache_key: "v4"
+          cache_key: "dpr-domain-builder-owasp-build-cache"

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -86,6 +86,7 @@ tasks {
   named<ShadowJar>("shadowJar") {
     archiveBaseName.set("domain-builder-backend-api")
     destinationDirectory.set(File("${project.rootDir}/build/libs"))
+    setProperty("zip64", true)
   }
 
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -48,6 +48,8 @@ dependencies {
 
   implementation("org.postgresql:postgresql:42.6.0")
 
+  implementation("org.apache.spark:spark-sql_2.12:2.4.0")
+
   kapt("io.micronaut:micronaut-inject-java")
   kapt("io.micronaut:micronaut-http-validation")
 

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/DomainController.kt
@@ -9,6 +9,7 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import uk.gov.justice.digital.backend.repository.DuplicateKeyException
 import uk.gov.justice.digital.backend.service.DomainService
+import uk.gov.justice.digital.backend.service.InvalidSparkSqlException
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.model.WriteableDomain
@@ -37,6 +38,11 @@ class DomainController(private val service: DomainService) {
     @Error(exception = DuplicateKeyException::class)
     fun duplicateKeyErrorHandler(): HttpResponse<Unit> {
         return HttpResponse.status(CONFLICT)
+    }
+
+    @Error(exception = InvalidSparkSqlException::class)
+    fun invalidSparkSqlErrorHandler(): HttpResponse<Unit> {
+        return HttpResponse.status(BAD_REQUEST)
     }
 
 }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainService.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainService.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.backend.service
 
 import jakarta.inject.Singleton
+import uk.gov.justice.digital.backend.repository.DomainRepository
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
-import uk.gov.justice.digital.backend.repository.DomainRepository
 import uk.gov.justice.digital.model.WriteableDomain
 import java.util.*
 

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainService.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainService.kt
@@ -2,9 +2,12 @@ package uk.gov.justice.digital.backend.service
 
 import jakarta.inject.Singleton
 import uk.gov.justice.digital.backend.repository.DomainRepository
+import uk.gov.justice.digital.backend.validator.InvalidSparkSql
+import uk.gov.justice.digital.backend.validator.SparkSqlValidator
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.model.WriteableDomain
+import java.lang.RuntimeException
 import java.util.*
 
 interface DomainService {
@@ -21,8 +24,23 @@ interface DomainService {
  * Update and delete to follow in later work.
  */
 @Singleton
-class RepositoryBackedDomainService(private val repository: DomainRepository): DomainService {
+class RepositoryBackedDomainService(
+    private val repository: DomainRepository,
+    private val sqlValidator: SparkSqlValidator): DomainService {
+
     override fun getDomains(name: String?, status: Status?): List<Domain> = repository.getDomains(name)
+
     override fun getDomain(id: UUID): Domain? = repository.getDomain(id)
-    override fun createDomain(domain: WriteableDomain): UUID = repository.createDomain(domain)
+
+    override fun createDomain(domain: WriteableDomain): UUID {
+        // Map list of tables and validate each mapping so we get a list of validation results
+        val results = domain.tables
+            .map { it.mapping.viewText }
+            .map { sqlValidator.validate(it) }
+            .filterNot { it.isValid }
+
+        if (results.isEmpty()) return repository.createDomain(domain)
+        // TODO - tidy this up
+        else throw RuntimeException((results.first() as InvalidSparkSql).reason)
+    }
 }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidator.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidator.kt
@@ -15,15 +15,15 @@ class SparkSqlValidator {
     fun validate(sparkSql: String): SparkSqlValidationResult {
         return try {
             validator.parseExpression(sparkSql)
-            ValidSparkSql()
+            ValidSparkSqlResult()
         } catch (ex: Exception) {
             logger.warn("Failed to validate spark SQL: '{}'", sparkSql)
-            InvalidSparkSql(ex.localizedMessage)
+            InvalidSparkSqlResult(ex.localizedMessage)
         }
     }
 
 }
 
 sealed interface SparkSqlValidationResult { val isValid: Boolean }
-class ValidSparkSql : SparkSqlValidationResult { override val isValid: Boolean = true }
-class InvalidSparkSql(val reason: String) : SparkSqlValidationResult { override val isValid: Boolean = false }
+class ValidSparkSqlResult : SparkSqlValidationResult { override val isValid: Boolean = true }
+class InvalidSparkSqlResult(val reason: String) : SparkSqlValidationResult { override val isValid: Boolean = false }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidator.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidator.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.backend.validator
+
+import jakarta.inject.Singleton
+import org.apache.spark.sql.execution.SparkSqlParser
+import org.apache.spark.sql.internal.SQLConf
+import org.slf4j.LoggerFactory
+
+@Singleton
+class SparkSqlValidator {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val validator = SparkSqlParser(SQLConf())
+
+    fun validate(sparkSql: String): SparkSqlValidationResult {
+        return try {
+            validator.parseExpression(sparkSql)
+            ValidSparkSql()
+        } catch (ex: Exception) {
+            logger.warn("Failed to validate spark SQL: '{}'", sparkSql)
+            InvalidSparkSql(ex.localizedMessage)
+        }
+    }
+
+}
+
+sealed interface SparkSqlValidationResult { val isValid: Boolean }
+class ValidSparkSql : SparkSqlValidationResult { override val isValid: Boolean = true }
+class InvalidSparkSql(val reason: String) : SparkSqlValidationResult { override val isValid: Boolean = false }

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainServiceTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainServiceTest.kt
@@ -6,11 +6,12 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertThrows
 import uk.gov.justice.digital.backend.repository.DomainRepository
-import uk.gov.justice.digital.backend.validator.InvalidSparkSql
+import uk.gov.justice.digital.backend.validator.InvalidSparkSqlResult
 import uk.gov.justice.digital.backend.validator.SparkSqlValidator
-import uk.gov.justice.digital.backend.validator.ValidSparkSql
+import uk.gov.justice.digital.backend.validator.ValidSparkSqlResult
 import uk.gov.justice.digital.model.WriteableDomain
 import uk.gov.justice.digital.test.Fixtures.mapping
+import uk.gov.justice.digital.test.Fixtures.transform
 import uk.gov.justice.digital.test.Fixtures.writeableDomain
 import java.util.*
 
@@ -25,18 +26,33 @@ class RepositoryBackedDomainServiceTest {
     @Test
     fun `create should create a domain containing valid spark sql`() {
         every { mockRepository.createDomain(any<WriteableDomain>()) } returns fixedUUID
-        every { mockValidator.validate(any()) } returns ValidSparkSql()
+        every { mockValidator.validate(any()) } returns ValidSparkSqlResult()
         val result = underTest.createDomain(writeableDomain)
         assertEquals(fixedUUID, result)
     }
 
     @Test
-    fun `create should throw an exception given a domain containing invalid spark sql`() {
-        every { mockValidator.validate(any()) } returns InvalidSparkSql("Parse failure message")
+    fun `create should throw an exception given a domain containing invalid mapping sql`() {
+        every { mockValidator.validate(any()) } returns InvalidSparkSqlResult("Parse failure message")
 
         val writeableDomainWithInvalidSql = writeableDomain.copy(
             tables = writeableDomain.tables.map {
                 it.copy(mapping = mapping.copy(viewText = "This is not valid SQL"))
+            }
+        )
+
+        assertThrows(InvalidSparkSqlException::class.java) {
+            underTest.createDomain(writeableDomainWithInvalidSql)
+        }
+    }
+
+    @Test
+    fun `create should throw an exception given a domain containing invalid transform sql`() {
+        every { mockValidator.validate(any()) } returns InvalidSparkSqlResult("Parse failure message")
+
+        val writeableDomainWithInvalidSql = writeableDomain.copy(
+            tables = writeableDomain.tables.map {
+                it.copy(transform = transform.copy(viewText = "This is not valid SQL"))
             }
         )
 

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainServiceTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainServiceTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.backend.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertThrows
+import uk.gov.justice.digital.backend.repository.DomainRepository
+import uk.gov.justice.digital.backend.validator.InvalidSparkSql
+import uk.gov.justice.digital.backend.validator.SparkSqlValidator
+import uk.gov.justice.digital.backend.validator.ValidSparkSql
+import uk.gov.justice.digital.model.WriteableDomain
+import uk.gov.justice.digital.test.Fixtures.mapping
+import uk.gov.justice.digital.test.Fixtures.writeableDomain
+import java.util.*
+
+class RepositoryBackedDomainServiceTest {
+
+    private val mockRepository: DomainRepository = mockk()
+    private val mockValidator: SparkSqlValidator = mockk()
+    private val fixedUUID = UUID.randomUUID()
+
+    private val underTest = RepositoryBackedDomainService(mockRepository, mockValidator)
+
+    @Test
+    fun `create should create a domain containing valid spark sql`() {
+        every { mockRepository.createDomain(any<WriteableDomain>()) } returns fixedUUID
+        every { mockValidator.validate(any()) } returns ValidSparkSql()
+        val result = underTest.createDomain(writeableDomain)
+        assertEquals(fixedUUID, result)
+    }
+
+    @Test
+    fun `create should throw an exception given a domain containing invalid spark sql`() {
+        every { mockValidator.validate(any()) } returns InvalidSparkSql("Parse failure message")
+
+        val writeableDomainWithInvalidSql = writeableDomain.copy(
+            tables = writeableDomain.tables.map {
+                it.copy(mapping = mapping.copy(viewText = "This is not valid SQL"))
+            }
+        )
+
+        assertThrows(RuntimeException::class.java) {
+            underTest.createDomain(writeableDomainWithInvalidSql)
+        }
+    }
+
+}

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainServiceTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainServiceTest.kt
@@ -40,7 +40,7 @@ class RepositoryBackedDomainServiceTest {
             }
         )
 
-        assertThrows(RuntimeException::class.java) {
+        assertThrows(InvalidSparkSqlException::class.java) {
             underTest.createDomain(writeableDomainWithInvalidSql)
         }
     }

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainServiceTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/RepositoryBackedDomainServiceTest.kt
@@ -3,16 +3,16 @@ package uk.gov.justice.digital.backend.service
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.backend.repository.DomainRepository
 import uk.gov.justice.digital.backend.validator.InvalidSparkSqlResult
 import uk.gov.justice.digital.backend.validator.SparkSqlValidator
 import uk.gov.justice.digital.backend.validator.ValidSparkSqlResult
 import uk.gov.justice.digital.model.WriteableDomain
-import uk.gov.justice.digital.test.Fixtures.mapping
-import uk.gov.justice.digital.test.Fixtures.transform
 import uk.gov.justice.digital.test.Fixtures.writeableDomain
+import uk.gov.justice.digital.test.Fixtures.writeableDomainWithInvalidMappingSql
+import uk.gov.justice.digital.test.Fixtures.writeableDomainWithInvalidTransformSql
 import java.util.*
 
 class RepositoryBackedDomainServiceTest {
@@ -35,14 +35,8 @@ class RepositoryBackedDomainServiceTest {
     fun `create should throw an exception given a domain containing invalid mapping sql`() {
         every { mockValidator.validate(any()) } returns InvalidSparkSqlResult("Parse failure message")
 
-        val writeableDomainWithInvalidSql = writeableDomain.copy(
-            tables = writeableDomain.tables.map {
-                it.copy(mapping = mapping.copy(viewText = "This is not valid SQL"))
-            }
-        )
-
         assertThrows(InvalidSparkSqlException::class.java) {
-            underTest.createDomain(writeableDomainWithInvalidSql)
+            underTest.createDomain(writeableDomainWithInvalidMappingSql)
         }
     }
 
@@ -50,14 +44,8 @@ class RepositoryBackedDomainServiceTest {
     fun `create should throw an exception given a domain containing invalid transform sql`() {
         every { mockValidator.validate(any()) } returns InvalidSparkSqlResult("Parse failure message")
 
-        val writeableDomainWithInvalidSql = writeableDomain.copy(
-            tables = writeableDomain.tables.map {
-                it.copy(transform = transform.copy(viewText = "This is not valid SQL"))
-            }
-        )
-
         assertThrows(InvalidSparkSqlException::class.java) {
-            underTest.createDomain(writeableDomainWithInvalidSql)
+            underTest.createDomain(writeableDomainWithInvalidTransformSql)
         }
     }
 

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidatorTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidatorTest.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.backend.validator
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SparkSqlValidatorTest {
+
+    private val underTest = SparkSqlValidator()
+
+    @Test
+    fun `should return a successful result given a valid SQL string`() {
+        val validationResult = underTest.validate("select * from foo")
+        assertTrue(validationResult.isValid)
+    }
+
+    @Test
+    fun `should return an unsuccessful result given an invalid SQL string`() {
+        val validationResult = underTest.validate("select a thing from foo")
+        assertFalse(validationResult.isValid)
+    }
+
+}

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ExceptionHandler.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ExceptionHandler.kt
@@ -45,16 +45,23 @@ object ExceptionHandler {
             """.trimIndent())
         }
         catch (brx: BadRequestException) {
+            val messageLines = brx.localizedMessage.split("\n")
+
             d.print("""
                 
                 @|red,bold Could not create new domain|@
                 
-                @|white,bold ${brx.localizedMessage}|@
-                 
+                @|white,bold ${messageLines.firstOrNull()}|@
             """.trimIndent())
+
+            // The error string may contain additional lines which should also be displayed where present
+            val errorDescription =
+                if (messageLines.size > 10) messageLines.drop(1).joinToString("\n")
+                else "\nNo reason was given.\n"
+
+            d.print(errorDescription)
         }
         catch (ex: Exception) {
-            println("Caught exception: $ex")
             d.print("""
                 
                 @|red,bold There was a problem with your request|@

--- a/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
+++ b/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
@@ -102,4 +102,16 @@ object Fixtures {
         tables = listOf(table1),
     )
 
+    val writeableDomainWithInvalidMappingSql = writeableDomain.copy(
+        tables = writeableDomain.tables.map {
+            it.copy(mapping = mapping.copy(viewText = "This is not valid SQL"))
+        }
+    )
+
+    val writeableDomainWithInvalidTransformSql = writeableDomain.copy(
+        tables = writeableDomain.tables.map {
+            it.copy(transform = transform.copy(viewText = "This is not valid SQL"))
+        }
+    )
+
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Settings to speed up gradle builds
 org.gradle.parallel=true
-org.gradle.caching=true
+org.gradle.caching=false
 
 # Kapt settings to enable caching
 kapt.classloaders.cache.size=3


### PR DESCRIPTION
Summary of changes
* introduced `SparkSqlValidator` that uses the `SparkSqlParser` to parse and thus validate a given Spark SQL string
* integrated the validator into the service layer which uses this to validate the query strings in any table mappings and transforms
* validation errors returned as a `BadRequest` with a `JsonError` response body that contains the detailed error message from the `SparkSqlParser`
* this response is formatted and displayed by the cli frontend
* test changes
* now need to enable `zip64` due to larger size of jar