### PR TITLE
DPR-594 temporarily remove Spark SQL validation and associated dependencies

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -19,7 +19,6 @@ micronaut {
 val kotlinVersion = "1.8.10"
 val ktormVersion = "3.6.0"
 val testContainersVersion = "1.18.0"
-val sparkVersion = "3.3.0"
 
 dependencies {
   implementation(project(":common"))
@@ -48,11 +47,6 @@ dependencies {
   runtimeOnly("io.micronaut.sql:micronaut-jdbc-dbcp")
 
   implementation("org.postgresql:postgresql:42.6.0")
-
-  // Spark dependencies
-  implementation("org.apache.spark:spark-sql_2.12:$sparkVersion")
-  implementation("org.apache.spark:spark-catalyst_2.12:$sparkVersion")
-  implementation("org.apache.spark:spark-core_2.12:$sparkVersion")
 
   kapt("io.micronaut:micronaut-inject-java")
   kapt("io.micronaut:micronaut-http-validation")

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidator.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidator.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.backend.validator
 
 import jakarta.inject.Singleton
-import org.apache.spark.sql.execution.SparkSqlParser
 import org.slf4j.LoggerFactory
 
 @Singleton
@@ -9,16 +8,10 @@ class SparkSqlValidator {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    private val validator = SparkSqlParser()
-
+    // TODO - reimplement Spark SQL validation. See DPR-600.
     fun validate(sparkSql: String): SparkSqlValidationResult {
-        return try {
-            validator.parseExpression(sparkSql)
-            ValidSparkSqlResult()
-        } catch (ex: Exception) {
-            logger.warn("Failed to validate spark SQL: '{}'", sparkSql)
-            InvalidSparkSqlResult(ex.localizedMessage)
-        }
+        logger.warn("Spark SQL validation not implemented. Treating query '{}' as valid.", sparkSql)
+        return ValidSparkSqlResult()
     }
 
 }

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidatorTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/validator/SparkSqlValidatorTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.backend.validator
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -14,7 +15,7 @@ class SparkSqlValidatorTest {
         assertTrue(validationResult.isValid)
     }
 
-    @Test
+    @Disabled
     fun `should return an unsuccessful result given an invalid SQL string`() {
         val validationResult = underTest.validate("select a thing from foo")
         assertFalse(validationResult.isValid)

--- a/bin/run-backend
+++ b/bin/run-backend
@@ -46,7 +46,7 @@ function check_jar_exists {
   then
     show_ok "Backend api jar exists in expected location"
   else
-    show_fail_and_exist "Backend api jar does not exist" "Review build output and check backend/build/libs contains the correctly named jar file"
+    show_fail_and_exit "Backend api jar does not exist" "Review build output and check backend/build/libs contains the correctly named jar file"
   fi
 }
 


### PR DESCRIPTION
Summary of changes
* in order to make progress in other tasks spark sql query validation has been temporarily removed along with the associated dependencies that are causing the jar size to exceed the maximum uncompressed size allowed by AWS Lambda
* this will be revisited in a later ticket as and when priorities allow