### PR TITLE
DPR-594 ensure cli list command handles empty array gracefully

### DIFF
--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
@@ -36,11 +36,8 @@ class ListDomains(private val service: DomainService) : Runnable {
 
     private fun fetchAndDisplayDomains() {
         val result = service.getAllDomains()
-
-        val output = generateOutput(result)
-
-        if (result.isEmpty()) parent.print("@|red,bold ERROR|@ No domains were found")
-        else parent.print(output)
+        if (result.isEmpty()) parent.print("\n@|bold No domains were found|@\n\n")
+        else parent.print(generateOutput(result))
     }
 
     private fun generateOutput(data: Array<Domain>): String {

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ListDomainsTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ListDomainsTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.cli.DomainBuilder
-import uk.gov.justice.digital.cli.command.ListDomains
 import uk.gov.justice.digital.cli.service.DomainService
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domain2
@@ -19,7 +18,7 @@ class ListDomainsTest {
     private val underTest = ListDomains(mockDomainService)
 
     @Test
-    fun listDomainsGeneratesExpectedOutput() {
+    fun `should generate a list of domains when domains exist`() {
 
         val capturedOutput = mutableListOf<String>()
 
@@ -41,6 +40,28 @@ class ListDomainsTest {
             | Domain 2 | DRAFT  | Another domain     |
             | Domain 3 | DRAFT  | Yet another domain |
             +----------+--------+--------------------+
+    
+""".trimIndent()
+
+        assertEquals(expectedOutput, capturedOutput.joinToString(""))
+    }
+
+    @Test
+    fun `should show a no domains found message when the api returns an empty list`() {
+
+        val capturedOutput = mutableListOf<String>()
+
+        underTest.parent = mockDomainBuilder
+
+        every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+        every { mockDomainService.getAllDomains() } answers { emptyArray() }
+
+        underTest.run()
+
+        val expectedOutput = """
+    
+            @|bold No domains were found|@
+            
     
 """.trimIndent()
 


### PR DESCRIPTION
Summary of changes
* minor fix to ensure that we don't try to generate a table if the list of domains is empty
* added a test case to cover this explicitly