### PR TITLE
More minor fixes for the domain builder

### DIFF
--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -8,18 +8,8 @@
        </encoder>
    </appender>
 
-  <appender name="CLOUDWATCH" class="io.micronaut.aws.cloudwatch.logging.CloudWatchLoggingAppender">
-        <appender-ref ref="CONSOLE"/>
-        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
-                <jsonFormatter class="io.micronaut.aws.cloudwatch.logging.CloudWatchJsonFormatter" />
-            </layout>
-        </encoder>
-    </appender>
-
-    <!-- when running locally set to CONSOLE to see MDC values -->
     <root level="INFO">
-      <appender-ref ref="CLOUDWATCH" />
+      <appender-ref ref="CONSOLE" />
     </root>
 
 </configuration>

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
@@ -56,7 +56,7 @@ class ListDomains(private val service: DomainService) : Runnable {
         )
         val dataRows = data.map {
             String.format(
-                "| %-${nameWidth}s | %-${statusWidth}s | %-${descriptionWidth}s |", it.name, it.status, it.description) }
+                "| %-${nameWidth}s | %-${statusWidth}s | %-${descriptionWidth}s |", it.name, it.status, it.description ?: "") }
         val footer = listOf("$tableBorder\n\n")
 
         return listOf(heading, dataRows, footer)

--- a/common/src/main/kotlin/uk/gov/justice/digital/model/WriteableDomain.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/model/WriteableDomain.kt
@@ -7,12 +7,12 @@ import io.micronaut.serde.annotation.Serdeable
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class WriteableDomain(
         val name: String,
-        val description: String,
-        val version: String,
-        val location: String,
+        val description: String?,
+        val version: String?,
+        val location: String?,
         val tags: Map<String, String> = emptyMap(),
-        val owner: String,
-        val author: String,
+        val owner: String?,
+        val author: String?,
         val tables: List<Table> = emptyList(),
         // The following fields are domain builder specific and can be omitted from the published domain.
         val status: Status = Status.DRAFT,


### PR DESCRIPTION
Summary of changes
* resolved issue with create ensuring the `WriteableDomain` model now aligns to the `Domain` model
* simplified logging config since the `CONSOLE` logger works fine in AWS
* removed duplication in exception handling
* added a try/catch around the main event loop and added slightly prettier exception output prompting the user to hit enter to return the domain builder - should an unexpected exception be thrown
* other minor tidying