### PR TITLE
DPR-616 change save key combination since CTRL-S is not getting sent on the ssm host

### DIFF
--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/editor/DomainEditor.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/editor/DomainEditor.kt
@@ -68,7 +68,7 @@ class DomainEditor(private val session: InteractiveSession, private val service:
         Field("Sources", ""),
         MultiLineField("Spark Query", ""),
         Blank(),
-        Heading("keys │ ↑ move up │ ↓ move down │ CTRL-s save │ ESC quit │ press enter to edit", "black", "white")
+        Heading("keys │ ↑ move up │ ↓ move down │ CTRL-W save │ ESC quit │ press enter to edit", "black", "white")
     )
 
     private fun updateDisplay(input: String? = null) {
@@ -370,7 +370,7 @@ class DomainEditor(private val session: InteractiveSession, private val service:
         map.bind(Operation.UP, "\u001B[A", "k")
         map.bind(Operation.DOWN, "\u001B[B", "j")
         map.bind(Operation.EDIT, "\r")
-        map.bind(Operation.SAVE, KeyMap.ctrl('S'))
+        map.bind(Operation.SAVE, KeyMap.ctrl('W'))
 
         // Set a shorter timeout for ambiguous keys so hitting ESC to exit is more responsive
         map.ambiguousTimeout = keyReaderTimeout

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/editor/TerminalExtensions.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/editor/TerminalExtensions.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.cli.editor
 import org.jline.terminal.Terminal
 import org.jline.utils.InfoCmp.Capability
 
-fun Terminal.hideCursor() = this.puts(Capability.cursor_invisible)
-fun Terminal.showCursor() = this.puts(Capability.cursor_visible)
+fun Terminal.hideCursor() = print("\u001B[?25l")
+fun Terminal.showCursor() = print("\u001B[?25h")
 
 fun Terminal.moveCursorToHome() {
     this.puts(Capability.cursor_home)
@@ -38,7 +38,7 @@ fun Terminal.clearLine() {
 
 fun Terminal.bell() {
     this.puts(Capability.bell)
-//    terminal.flush()
+    this.flush()
 }
 
 fun Terminal.saveCursorPosition() = print("\u001B7")

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/editor/TextEditor.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/editor/TextEditor.kt
@@ -42,8 +42,9 @@ class TextEditor(private val session: InteractiveSession, private val heading: S
         val originalAttributes = terminal.enterRawMode()
 
         terminal.showCursor()
-        terminal.clearDisplay()
+        terminal.flush()
 
+        terminal.clearDisplay()
         terminal.flush()
 
         val padding = " ".repeat(terminal.width - heading.length - 1)
@@ -72,12 +73,13 @@ class TextEditor(private val session: InteractiveSession, private val heading: S
         terminal.saveCursorPosition()
         terminal.moveCursorTo(23, 0)
 
-        val statusLine = "keys │ ↑ move up │ ↓ move down │ ← move left │ → move right │ CTRL-S save │ ESC exit"
+        val statusLine = "keys │ ↑ move up │ ↓ move down │ ← move left │ → move right │ CTRL-W save │ ESC exit"
             .take(terminal.width - 2)
-        val statusPadding = " ".repeat(terminal.width - min(statusLine.length, terminal.width - 1))
+        val statusPadding = " ".repeat(terminal.width - min(statusLine.length, terminal.width) - 1)
         print(session.toAnsi("@|fg(black),bg(white),bold  $statusLine$statusPadding|@"))
 
         terminal.restoreSavedCursorPosition()
+        terminal.showCursor()
         terminal.flush()
 
         while(true) {
@@ -241,7 +243,7 @@ class TextEditor(private val session: InteractiveSession, private val heading: S
         map.bind(ENTER, "\r")
         map.bind(DELETE, "\b")
         map.bind(EXIT, "\u001B")
-        map.bind(ACCEPT, KeyMap.ctrl('S'))
+        map.bind(ACCEPT, KeyMap.ctrl('W'))
 
         // Allow user to enter characters which are passed to the insert handler.
         for (i in 32..255) {

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
@@ -17,6 +17,7 @@ import org.jline.terminal.TerminalBuilder
 import org.jline.widget.AutosuggestionWidgets
 import picocli.CommandLine
 import picocli.shell.jline3.PicocliCommands
+import uk.gov.justice.digital.headers.SessionIdHeader
 import java.io.ByteArrayInputStream
 
 interface ConsoleSession {
@@ -117,7 +118,8 @@ class InteractiveSession: ConsoleSession {
     companion object {
         private const val prompt = "domain-builder> "
         private const val tabCompletionMaxCandidates = 50
-        private val historyFileLocation = "${System.getProperty("user.home")}/.domain-builder_history"
+        // Create a unique history file in /tmp per session - and use the session ID to identify it.
+        private val historyFileLocation = "${System.getProperty("java.io.tmpdir")}/domain-builder-session-${SessionIdHeader.instance.value}.history"
         private const val historySize = 100
 
         private val launchText = """


### PR DESCRIPTION
Summary of changes
* change `CTRL-S` key sequence to `CTRL-W` since the former isn't getting sent on the ssm host for some reason
* history file is now session specific and written to `tmp` ensuring isolation between successive runs
* switch to raw escape sequences to control cursor show/hide since this seems to be more reliable