### PR TITLE
DPR-612 add preview support to CLI

### DIFF
--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/client/preview/AthenaPreviewClient.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/client/preview/AthenaPreviewClient.kt
@@ -10,7 +10,7 @@ class AthenaPreviewClient(@Named("preview") private val previewDataSource: DataS
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    override fun runQuery(query: String): List<Map<String, String>> {
+    override fun runQuery(query: String): List<List<String>> {
         logger.info("Executing query: {}", query)
         val startTime = System.currentTimeMillis()
         val statement = previewDataSource.connection.createStatement()
@@ -25,10 +25,14 @@ class AthenaPreviewClient(@Named("preview") private val previewDataSource: DataS
         val columnNames = (1..columnCount)
             .map { metadata.getColumnName(it) }
 
-        val result = mutableListOf<Map<String, String>>()
+        // First row of result contains the column names
+        val result = mutableListOf<List<String>>(columnNames)
 
         while(resultSet.next()) {
-            result.add( columnNames.associateWith { resultSet.getString(it) } )
+            val row = (1..columnCount)
+                .map { resultSet.getString(it) }
+
+            result.add(row)
         }
 
         logger.info("Query returned {} row{}", result.size, if (result.size != 1) "s" else "")

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/client/preview/PreviewClient.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/client/preview/PreviewClient.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.backend.client.preview
 
 interface PreviewClient {
 
-    fun runQuery(query: String): List<Map<String, String>>
+    fun runQuery(query: String): List<List<String>>
 
 }

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/PreviewController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/PreviewController.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.backend.service.DomainNotFoundException
 import uk.gov.justice.digital.backend.service.NoTablesInDomainException
 import uk.gov.justice.digital.backend.service.PreviewService
 import uk.gov.justice.digital.model.Status
-import java.util.*
 
 @Controller("/preview")
 class PreviewController(private val service: PreviewService) {

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/PreviewController.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/controller/PreviewController.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.model.Status
 class PreviewController(private val service: PreviewService) {
 
     @Post(consumes = [APPLICATION_JSON], produces = [APPLICATION_JSON])
-    fun runPreview(domainName: String, status: Status, limit: Int): List<Map<String, String>> =
+    fun runPreview(domainName: String, status: Status, limit: Int): List<List<String>> =
         service.preview(domainName, status, limit)
 
     @Error(exception = DomainNotFoundException::class)

--- a/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/AthenaPreviewService.kt
+++ b/backend/src/main/kotlin/uk/gov/justice/digital/backend/service/AthenaPreviewService.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.model.Status
 import kotlin.math.min
 
 interface PreviewService {
-    fun preview(domainName: String, status: Status, limit: Int): List<Map<String, String>>
+    fun preview(domainName: String, status: Status, limit: Int): List<List<String>>
 
     companion object {
         const val MaximumLimit = 100
@@ -20,7 +20,7 @@ class AthenaPreviewService(private val client: PreviewClient,
                            private val repository: DomainRepository,
                            private val converter: DomainToPreviewQueryConverter): PreviewService {
 
-    override fun preview(domainName: String, status: Status, limit: Int): List<Map<String, String>> {
+    override fun preview(domainName: String, status: Status, limit: Int): List<List<String>> {
         val domains = repository.getDomains(domainName, status)
 
         val domain = domains.firstOrNull()
@@ -33,7 +33,7 @@ class AthenaPreviewService(private val client: PreviewClient,
             ?: throw NoTablesInDomainException("No tables found in domain with name: $domainName status: $status")
     }
 
-    private fun preview(sql: String, limit: Int): List<Map<String, String>> {
+    private fun preview(sql: String, limit: Int): List<List<String>> {
         val convertedQuery = converter.convertQuery(sql, min(limit, PreviewService.MaximumLimit))
         return client.runQuery(convertedQuery)
     }

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/client/preview/AthenaPreviewClientTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/client/preview/AthenaPreviewClientTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.backend.client.preview
 
 import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.postgresql.ds.PGSimpleDataSource
@@ -49,17 +50,29 @@ class AthenaPreviewClientTest {
 
         val result = underTest.runQuery("select * from test_domain")
 
-        Assertions.assertEquals(5, result.size)
+        assertEquals(6, result.size)
 
-        val expectedFirstRow = mapOf(
-            "id" to "1",
-            "name" to "Foo",
-            "street" to "Montague Road",
-            "postcode" to "SW12 2PB",
-            "items" to "5"
+        val headingsRow = listOf(
+            "id",
+            "name",
+            "street",
+            "postcode",
+            "items"
         )
 
-        Assertions.assertEquals(expectedFirstRow, result[0])
+        val firstDataRow = listOf(
+            "1",
+            "Foo",
+            "Montague Road",
+            "SW12 2PB",
+            "5"
+        )
+
+        // First row of results contains headings...
+        assertEquals(headingsRow, result[0])
+        // ...followed by data.
+        assertEquals(firstDataRow, result[1])
+
     }
 
 }

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/PreviewControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/PreviewControllerTest.kt
@@ -44,9 +44,8 @@ class PreviewControllerTest {
     @Test
     fun `request for valid domain returns a HTTP 200 response containing the preview data`() {
         val fakeData = listOf(
-            mapOf("foo" to "1"),
-            mapOf("bar" to "1"),
-            mapOf("baz" to "1"),
+            listOf("foo", "bar", "baz"),
+            listOf("1", "1", "1")
         )
 
         every { mockPreviewService.preview("someDomain", Status.DRAFT, 10) } returns fakeData

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/PreviewControllerTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/controller/PreviewControllerTest.kt
@@ -22,7 +22,6 @@ import uk.gov.justice.digital.backend.service.PreviewService
 import uk.gov.justice.digital.headers.Header
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.test.Fixtures
-import java.util.*
 
 @MicronautTest
 class PreviewControllerTest {

--- a/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/AthenaPreviewServiceTest.kt
+++ b/backend/src/test/kotlin/uk/gov/justice/digital/backend/service/AthenaPreviewServiceTest.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.backend.service
 
 import io.mockk.every
-import io.mockk.verify
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.model.Table
 import uk.gov.justice.digital.model.Transform
 import uk.gov.justice.digital.test.Fixtures.domain1
-import uk.gov.justice.digital.test.Fixtures.domain2
 import uk.gov.justice.digital.test.Fixtures.table1
 
 class AthenaPreviewServiceTest {
@@ -33,7 +32,7 @@ class AthenaPreviewServiceTest {
             listOf(table1.copy(transform = Transform(queryString, emptyList())))
         )
 
-        val mockResult = listOf(mapOf("foo" to "bar"))
+        val mockResult = listOf(listOf("foo"), listOf("bar"))
 
         every { mockRepository.getDomains(any(), any()) } answers { listOf(domainWithTestDomainQuery) }
         every { mockClient.runQuery(any()) } answers { mockResult }
@@ -50,7 +49,7 @@ class AthenaPreviewServiceTest {
             listOf(table1.copy(transform = Transform(queryString, emptyList())))
         )
 
-        val mockResult = listOf(mapOf("foo" to "bar"))
+        val mockResult = listOf(listOf("foo"), listOf("bar"))
 
         every { mockRepository.getDomains(any(), any()) } answers { listOf(domainWithTestDomainQuery) }
         every { mockClient.runQuery(any()) } answers { mockResult }
@@ -69,7 +68,7 @@ class AthenaPreviewServiceTest {
             listOf(table1.copy(transform = Transform(queryString, emptyList())))
         )
 
-        val mockResult = listOf(mapOf("foo" to "bar"))
+        val mockResult = listOf(listOf("foo"), listOf("bar"))
 
         every { mockRepository.getDomains(any(), any()) } answers { listOf(domainWithTestDomainQuery) }
         every { mockClient.runQuery(any()) } answers { mockResult }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/DomainBuilder.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/DomainBuilder.kt
@@ -6,12 +6,9 @@ import jakarta.inject.Singleton
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
-import uk.gov.justice.digital.cli.command.CreateDomain
-import uk.gov.justice.digital.cli.command.ListDomains
-import uk.gov.justice.digital.cli.command.ViewDomain
+import uk.gov.justice.digital.cli.command.*
 import uk.gov.justice.digital.cli.session.BatchSession
 import uk.gov.justice.digital.cli.session.InteractiveSession
-import uk.gov.justice.digital.cli.command.CreateDomainInteractive
 import kotlin.system.exitProcess
 
 @Command(
@@ -21,6 +18,7 @@ import kotlin.system.exitProcess
         ViewDomain::class,
         CreateDomain::class,
         CreateDomainInteractive::class,
+        PreviewDomain::class,
     ],
 )
 @Singleton

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/DomainBuilder.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/DomainBuilder.kt
@@ -8,6 +8,7 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import uk.gov.justice.digital.cli.command.*
 import uk.gov.justice.digital.cli.session.BatchSession
+import uk.gov.justice.digital.cli.session.ConsoleSession
 import uk.gov.justice.digital.cli.session.InteractiveSession
 import kotlin.system.exitProcess
 
@@ -39,7 +40,7 @@ class DomainBuilder(
         description = ["Run domain-builder in interactive mode"],
         required = false
     )
-    private var isInteractive = false
+    private var interactive = false
 
     @Option(
         names = ["--enable-ansi"],
@@ -51,24 +52,28 @@ class DomainBuilder(
     override fun run() {
         System.setProperty("picocli.ansi", "$ansiEnabled")
 
-        if (isInteractive) {
+        if (interactive) {
             val commandLine = CommandLine(this, MicronautFactory())
             interactiveSession.start(commandLine)
         }
     }
 
     fun print(s: String) {
-        if (isInteractive) interactiveSession.print(s)
+        if (interactive) interactiveSession.print(s)
         else batchSession.print(s)
     }
 
     fun getInteractiveSession(): InteractiveSession {
-        if (isInteractive) return interactiveSession
+        if (interactive) return interactiveSession
         else {
             println("\nThis command is only available when run interactively\n")
             exitProcess(1)
         }
     }
+
+    fun session(): ConsoleSession =
+        if (interactive) interactiveSession
+        else batchSession
 
     companion object {
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
@@ -31,7 +31,7 @@ interface DomainClient {
     fun getDomains(): Array<Domain>
     fun getDomains(name: String, status: Status? = null): Array<Domain>
     fun createDomain(domain: WriteableDomain): String
-    fun previewDomain(name: String, status: Status, limit: Int): Array<Map<String, String>>
+    fun previewDomain(name: String, status: Status, limit: Int): Array<Array<String>>
 }
 
 /**
@@ -122,7 +122,7 @@ class BlockingDomainClient : DomainClient {
             ?.let { objectMapper.readValue(it, T::class.java) }
             ?: throw UnexpectedResponseException("No data in response")
 
-    override fun previewDomain(name: String, status: Status, limit: Int): Array<Map<String, String>> {
+    override fun previewDomain(name: String, status: Status, limit: Int): Array<Array<String>> {
         val requestBody = mapOf(
             "domainName" to name,
             "status" to status,

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
@@ -135,11 +135,9 @@ class BlockingDomainClient : DomainClient {
 
         val response: HttpResponse<String> = client.send(request, HttpResponse.BodyHandlers.ofString())
 
-        // TODO - this could be factored out into the deserialize method and shared
         if (response.statusCode() == 200) return response.deserialize()
         else throw UnexpectedResponseException("Server returned an unexpected response: HTTP ${response.statusCode()}")
     }
-
 
     private fun <T> createErrorMessageForBadRequest(response: HttpResponse<T>) = response.headers()
             .firstValue(CONTENT_TYPE)

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.cli.client
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.type.Argument
-import io.micronaut.core.type.GenericArgument;
 import io.micronaut.http.HttpHeaders.*
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.HttpStatus.*
@@ -89,7 +88,7 @@ class BlockingDomainClient : DomainClient {
 
     private fun HttpRequest.Builder.withCustomHeader(header: Header) = this.header(header.name, header.value)
 
-    private inline fun <reified T> HttpClient.get(uri: URI, type: Argument<T> = Argument.of(T::class.java)): T {
+    private inline fun <reified T> HttpClient.get(uri: URI, type: Argument<T>): T {
         val request = configuredRequestBuilder(uri)
             .GET()
             .build()
@@ -119,7 +118,7 @@ class BlockingDomainClient : DomainClient {
         }
     }
 
-    private inline fun <reified T> HttpResponse<String>.deserialize(type: Argument<T> = Argument.of(T::class.java)): T =
+    private inline fun <reified T> HttpResponse<String>.deserialize(type: Argument<T>): T =
         this.body()
             ?.let { objectMapper.readValue(it, type) }
             ?: throw UnexpectedResponseException("No data in response")

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
@@ -31,6 +31,7 @@ interface DomainClient {
     fun getDomains(): Array<Domain>
     fun getDomains(name: String, status: Status? = null): Array<Domain>
     fun createDomain(domain: WriteableDomain): String
+    fun previewDomain(name: String, status: Status): Array<Map<String, String>>
 }
 
 /**
@@ -51,6 +52,10 @@ class BlockingDomainClient : DomainClient {
     private lateinit var apiKey: String
 
     private val domainResource by lazy {
+        UriBuilder.of("$baseUrl/domain").build()
+    }
+
+    private val previewResource by lazy {
         UriBuilder.of("$baseUrl/domain").build()
     }
 
@@ -110,6 +115,10 @@ class BlockingDomainClient : DomainClient {
             BAD_REQUEST -> throw BadRequestException(createErrorMessageForBadRequest(response))
             else -> throw UnexpectedResponseException("Got unexpected response from server: $response")
         }
+    }
+
+    override fun previewDomain(name: String, status: Status): Array<Map<String, String>> {
+        TODO("Not yet implemented")
     }
 
     private fun <T> createErrorMessageForBadRequest(response: HttpResponse<T>) = response.headers()

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
@@ -4,6 +4,7 @@ import jakarta.inject.Singleton
 import picocli.CommandLine.*
 import uk.gov.justice.digital.cli.DomainBuilder
 import uk.gov.justice.digital.cli.command.ExceptionHandler.runAndHandleExceptions
+import uk.gov.justice.digital.cli.output.Table
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.cli.service.DomainService
 
@@ -24,11 +25,6 @@ class ListDomains(private val service: DomainService) : Runnable {
     @ParentCommand
     lateinit var parent: DomainBuilder
 
-    private val padding = 2
-    private val defaultNameWidth = 4
-    private val defaultStatusWidth = 6
-    private val defaultDescriptionWidth = 10
-
     override fun run() =
         runAndHandleExceptions(parent) {
             fetchAndDisplayDomains()
@@ -41,41 +37,20 @@ class ListDomains(private val service: DomainService) : Runnable {
     }
 
     private fun generateOutput(data: Array<Domain>): String {
-        // Format name and description widths dynamically
-        val nameWidth = data.maxOf { it.name.length }.let { if (it > defaultNameWidth) it else defaultNameWidth }
-        val statusWidth = data.maxOf { it.status.name.length }.let { if (it > defaultStatusWidth) it else defaultStatusWidth }
-        val descriptionWidth = data.maxOf { it.description?.length ?: 0 }.let { if (it > defaultDescriptionWidth) it else defaultDescriptionWidth }
 
-        val tableBorder = tableRowBorder(nameWidth, statusWidth, descriptionWidth)
+        val heading = "\n@|bold,green Found ${data.size} domains|@\n"
 
-        val heading = listOf(
-            "\n@|bold,green Found ${data.size} domains|@\n",
-            tableBorder,
-            String.format("| @|bold %-${nameWidth}s|@ | @|bold %-${statusWidth}s|@ | @|bold %-${descriptionWidth}s|@ |", "Name", "Status", "Description"),
-            tableBorder,
-        )
-        val dataRows = data.map {
-            String.format(
-                "| %-${nameWidth}s | %-${statusWidth}s | %-${descriptionWidth}s |", it.name, it.status, it.description ?: "") }
-        val footer = listOf("$tableBorder\n\n")
+        val tableData = data.map {
+            arrayOf(it.name, it.status.name, it.description ?: "")
+        }.toTypedArray()
 
-        return listOf(heading, dataRows, footer)
-            .flatten()
-            .joinToString("\n")
-    }
+        val renderedTable = Table(arrayOf("Name", "Status", "Description"), tableData).render()
 
-    /**
-     * Creates a horizontal table row line for the given number of column widths.
-     * For example tableRowDelimiter(2, 2, 2) will return
-     * +----+----+----+
-     * which can be used between table rows e.g.
-     * +----+----+----+
-     * | C1 | C2 | C3 |
-     * +----+----+----+
-     */
-    private fun tableRowBorder(vararg columnWidths: Int): String {
-        return columnWidths
-            .joinToString(separator = "+", prefix = "+", postfix = "+") { "-".repeat(it + padding) }
+        return listOf(
+            heading,
+            renderedTable,
+            "\n"
+        ).joinToString("\n")
     }
 
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ListDomains.kt
@@ -36,15 +36,15 @@ class ListDomains(private val service: DomainService) : Runnable {
         else parent.print(generateOutput(result))
     }
 
-    private fun generateOutput(data: Array<Domain>): String {
+    private fun generateOutput(data: List<Domain>): String {
 
         val heading = "\n@|bold,green Found ${data.size} domains|@\n"
 
         val tableData = data.map {
-            arrayOf(it.name, it.status.name, it.description ?: "")
-        }.toTypedArray()
+            listOf(it.name, it.status.name, it.description)
+        }
 
-        val renderedTable = Table(arrayOf("Name", "Status", "Description"), tableData).render()
+        val renderedTable = Table(listOf("Name", "Status", "Description"), tableData).render()
 
         return listOf(
             heading,

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -4,6 +4,7 @@ import jakarta.inject.Singleton
 import picocli.CommandLine
 import uk.gov.justice.digital.cli.DomainBuilder
 import uk.gov.justice.digital.cli.command.ExceptionHandler.runAndHandleExceptions
+import uk.gov.justice.digital.cli.output.Table
 import uk.gov.justice.digital.cli.service.DomainService
 import uk.gov.justice.digital.model.Status
 
@@ -51,13 +52,16 @@ class PreviewDomain(private val service: DomainService) : Runnable {
 
     override fun run() =
         runAndHandleExceptions(parent) {
-            // TODO - look at the best way to make the limit dynamic (interactive only :/)
+            // TODO - look at the best way to make the limit dynamic (interactive only)
             val result = service.previewDomain(domainName(), domainStatus, 25)
-            // TODO - generate tabulated output
-            result.forEach { parent.print("$it\n") }
+            val output = generateOutput(result)
+            parent.print("\n@|bold, green Previewing domain ${domainName()} with status ${domainStatus}|@\n\n")
+            parent.print(output)
+            parent.print("\n")
         }
 
-    private fun generateOutput(data: List<Map<String, String>>): String {
-        return ""
-    }
+    private fun generateOutput(data: Array<Array<String>>) =
+        Table(headings = data[0], data = data.copyOfRange(1, data.size))
+            .render()
+
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -52,8 +52,7 @@ class PreviewDomain(private val service: DomainService) : Runnable {
 
     override fun run() =
         runAndHandleExceptions(parent) {
-            // TODO - look at the best way to make the limit dynamic (interactive only)
-            val result = service.previewDomain(domainName(), domainStatus, 25)
+            val result = service.previewDomain(domainName(), domainStatus, displayHeight())
             val output = generateOutput(result)
             parent.print("\n@|bold, green Previewing domain ${domainName()} with status ${domainStatus}|@\n\n")
             parent.print(output)
@@ -64,4 +63,7 @@ class PreviewDomain(private val service: DomainService) : Runnable {
         Table(headings = data[0], data = data.copyOfRange(1, data.size))
             .render()
 
+    private fun displayHeight() =
+        if (parent.session().isInteractive()) parent.getInteractiveSession().terminal().height
+        else 20
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -59,8 +59,8 @@ class PreviewDomain(private val service: DomainService) : Runnable {
             parent.print("\n")
         }
 
-    private fun generateOutput(data: Array<Array<String>>) =
-        Table(headings = data[0], data = data.copyOfRange(1, data.size))
+    private fun generateOutput(data: List<List<String?>>) =
+        Table(headings = data[0].map { it ?: "" }, data = data.subList(1, data.size))
             .render()
 
     private fun displayHeight() =

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -68,6 +68,12 @@ class PreviewDomain(private val service: DomainService) : Runnable {
         ).render()
 
     private fun displayHeight() =
-        if (parent.session().isInteractive()) parent.getInteractiveSession().terminal().height - 8
-        else 10
+        // Retrieve enough data to fill the current screen size allowing for headings.
+        if (parent.session().isInteractive()) parent.getInteractiveSession().terminal().height - NON_DATA_ROWS
+        else BATCH_SESSION_LIMIT
+
+    companion object {
+        const val BATCH_SESSION_LIMIT = 10
+        const val NON_DATA_ROWS = 8
+    }
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -4,6 +4,7 @@ import jakarta.inject.Singleton
 import picocli.CommandLine
 import uk.gov.justice.digital.cli.DomainBuilder
 import uk.gov.justice.digital.cli.command.ExceptionHandler.runAndHandleExceptions
+import uk.gov.justice.digital.cli.service.DomainService
 import uk.gov.justice.digital.model.Status
 
 @Singleton
@@ -11,7 +12,7 @@ import uk.gov.justice.digital.model.Status
     name = "preview",
     description = ["Preview the data in a specific domain"]
 )
-class PreviewDomain : Runnable {
+class PreviewDomain(private val service: DomainService) : Runnable {
 
     @CommandLine.Option(
         names = ["-h", "--help"],
@@ -22,7 +23,7 @@ class PreviewDomain : Runnable {
     @CommandLine.Option(
         names = ["-n", "--name"],
         description = [
-            "the name of the domain to view",
+            "the name of the domain to preview",
         ],
         arity = "1..*",
         required = true,
@@ -33,7 +34,7 @@ class PreviewDomain : Runnable {
     @CommandLine.Option(
         names = ["-s", "--status"],
         description = [
-            "the status of the domain to view, either DRAFT or PUBLISHED"
+            "the status of the domain to preview, either DRAFT or PUBLISHED"
         ],
         arity = "1",
         required = true,
@@ -50,7 +51,9 @@ class PreviewDomain : Runnable {
 
     override fun run() =
         runAndHandleExceptions(parent) {
-            parent.print("TODO\n")
+            val result = service.previewDomain(domainName(), domainStatus)
+            // TODO - generate tabulated output
+            result.forEach { parent.print("$it\n") }
         }
 
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.cli.command
+
+import jakarta.inject.Singleton
+import picocli.CommandLine
+import uk.gov.justice.digital.cli.DomainBuilder
+import uk.gov.justice.digital.cli.command.ExceptionHandler.runAndHandleExceptions
+import uk.gov.justice.digital.model.Status
+
+@Singleton
+@CommandLine.Command(
+    name = "preview",
+    description = ["Preview the data in a specific domain"]
+)
+class PreviewDomain : Runnable {
+
+    @CommandLine.Option(
+        names = ["-h", "--help"],
+        description = [ "display this help message" ]
+    )
+    var usageHelpRequested = false
+
+    @CommandLine.Option(
+        names = ["-n", "--name"],
+        description = [
+            "the name of the domain to view",
+        ],
+        arity = "1..*",
+        required = true,
+        paramLabel = "DOMAIN_NAME",
+    )
+    lateinit var domainNameElements: Array<String>
+
+    @CommandLine.Option(
+        names = ["-s", "--status"],
+        description = [
+            "the status of the domain to view, either DRAFT or PUBLISHED"
+        ],
+        arity = "1",
+        required = true,
+        paramLabel = "STATUS",
+    )
+    lateinit var domainStatus: Status
+
+    private fun domainName(): String {
+        return domainNameElements.joinToString(" ")
+    }
+
+    @CommandLine.ParentCommand
+    lateinit var parent: DomainBuilder
+
+    override fun run() =
+        runAndHandleExceptions(parent) {
+            parent.print("TODO\n")
+        }
+
+}

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -57,4 +57,7 @@ class PreviewDomain(private val service: DomainService) : Runnable {
             result.forEach { parent.print("$it\n") }
         }
 
+    private fun generateOutput(data: List<Map<String, String>>): String {
+        return ""
+    }
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -68,6 +68,6 @@ class PreviewDomain(private val service: DomainService) : Runnable {
         ).render()
 
     private fun displayHeight() =
-        if (parent.session().isInteractive()) parent.getInteractiveSession().terminal().height
-        else 20
+        if (parent.session().isInteractive()) parent.getInteractiveSession().terminal().height - 8
+        else 10
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -53,15 +53,19 @@ class PreviewDomain(private val service: DomainService) : Runnable {
     override fun run() =
         runAndHandleExceptions(parent) {
             val result = service.previewDomain(domainName(), domainStatus, displayHeight())
-            val output = generateOutput(result)
-            parent.print("\n@|bold, green Previewing domain ${domainName()} with status ${domainStatus}|@\n\n")
+            val output = listOf(
+                "\n@|bold,green Previewing domain ${domainName()} with status ${domainStatus}|@\n",
+                generateOutput(result),
+                ""
+            ).joinToString("\n")
             parent.print(output)
-            parent.print("\n")
         }
 
     private fun generateOutput(data: List<List<String?>>) =
-        Table(headings = data[0].map { it ?: "" }, data = data.subList(1, data.size))
-            .render()
+        Table(
+            headings = data[0].map { it ?: "" },
+            data = data.subList(1, data.size)
+        ).render()
 
     private fun displayHeight() =
         if (parent.session().isInteractive()) parent.getInteractiveSession().terminal().height

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -51,7 +51,8 @@ class PreviewDomain(private val service: DomainService) : Runnable {
 
     override fun run() =
         runAndHandleExceptions(parent) {
-            val result = service.previewDomain(domainName(), domainStatus)
+            // TODO - look at the best way to make the limit dynamic (interactive only :/)
+            val result = service.previewDomain(domainName(), domainStatus, 25)
             // TODO - generate tabulated output
             result.forEach { parent.print("$it\n") }
         }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
@@ -17,8 +17,7 @@ class Table(private val headings: List<String>, private val data: List<List<Stri
 
     // Determine maximum value lengths per column for formatting.
     private val maxColumnWidths = headings.mapIndexed { index: Int, value: String ->
-        // TODO - review this
-        val longestColumnValue = data.maxOfOrNull { it[index]?.length ?: Int.MIN_VALUE } ?: Int.MIN_VALUE
+        val longestColumnValue = data.maxOf { it[index]?.length ?: Int.MIN_VALUE }
         max(value.length, longestColumnValue)
     }
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
@@ -13,11 +13,12 @@ import uk.gov.justice.digital.cli.output.Table.TableElements.TopRightCorner
 import uk.gov.justice.digital.cli.output.Table.TableElements.VerticalLine
 import kotlin.math.max
 
-class Table(private val headings: Array<String>, private val data: Array<Array<String>>) {
+class Table(private val headings: List<String>, private val data: List<List<String?>>) {
 
     // Determine maximum value lengths per column for formatting.
     private val maxColumnWidths = headings.mapIndexed { index: Int, value: String ->
-        val longestColumnValue = data.maxOfOrNull { it[index].length } ?: Int.MIN_VALUE
+        // TODO - review this
+        val longestColumnValue = data.maxOfOrNull { it[index]?.length ?: Int.MIN_VALUE } ?: Int.MIN_VALUE
         max(value.length, longestColumnValue)
     }
 
@@ -54,8 +55,8 @@ class Table(private val headings: Array<String>, private val data: Array<Array<S
 
     private fun generateDataRows(): String =
         data.joinToString("\n") {
-            it.mapIndexed { index: Int, value: String ->
-                columnFormatStrings[index].format(value)
+            it.mapIndexed { index: Int, value: String? ->
+                columnFormatStrings[index].format(value ?: "")
             }.joinToString(prefix = VerticalLine, separator = VerticalLine, postfix = VerticalLine)
         }
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
@@ -36,8 +36,10 @@ class Table(private val headings: Array<String>, private val data: Array<Array<S
             .joinToString(prefix = TopLeftCorner, separator = ColumnSeparatorTop, postfix = TopRightCorner) {
                 HorizontalLine.repeat(it + 2)
             }
+
         val headingsLine = headings.mapIndexed { index, value ->
-            columnFormatStrings[index].format(value)
+            // Render headings in bold
+            "@|bold ${columnFormatStrings[index].format(value)}|@"
         }
         .joinToString(prefix = VerticalLine, separator = VerticalLine, postfix = VerticalLine)
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.cli.output
 
-import uk.gov.justice.digital.cli.output.Table.TableElements.HeadingSeparatorBottom
-import uk.gov.justice.digital.cli.output.Table.TableElements.HeadingSeparatorTop
+import uk.gov.justice.digital.cli.output.Table.TableElements.BottomLeftCorner
+import uk.gov.justice.digital.cli.output.Table.TableElements.BottomRightCorner
+import uk.gov.justice.digital.cli.output.Table.TableElements.ColumnSeparatorBottom
+import uk.gov.justice.digital.cli.output.Table.TableElements.ColumnSeparatorTop
 import uk.gov.justice.digital.cli.output.Table.TableElements.HorizontalConnectorLeft
 import uk.gov.justice.digital.cli.output.Table.TableElements.HorizontalConnectorRight
 import uk.gov.justice.digital.cli.output.Table.TableElements.HorizontalLine
+import uk.gov.justice.digital.cli.output.Table.TableElements.HorizontalVerticalConnector
 import uk.gov.justice.digital.cli.output.Table.TableElements.TopLeftCorner
 import uk.gov.justice.digital.cli.output.Table.TableElements.TopRightCorner
 import uk.gov.justice.digital.cli.output.Table.TableElements.VerticalLine
@@ -24,12 +27,13 @@ class Table(private val headings: Array<String>, private val data: Array<Array<S
         return listOf(
             generateColumnHeadings(),
             generateDataRows(),
+            generateClosingRow(),
         ).joinToString("\n")
     }
 
     private fun generateColumnHeadings(): String {
         val headingsTopBar = maxColumnWidths
-            .joinToString(prefix = TopLeftCorner, separator = HeadingSeparatorTop, postfix = TopRightCorner) {
+            .joinToString(prefix = TopLeftCorner, separator = ColumnSeparatorTop, postfix = TopRightCorner) {
                 HorizontalLine.repeat(it + 2)
             }
         val headingsLine = headings.mapIndexed { index, value ->
@@ -39,28 +43,25 @@ class Table(private val headings: Array<String>, private val data: Array<Array<S
 
 
         val headingsBottomBar = maxColumnWidths
-            .joinToString(prefix = HorizontalConnectorLeft, separator = HeadingSeparatorBottom, postfix = HorizontalConnectorRight) {
+            .joinToString(prefix = HorizontalConnectorLeft, separator = HorizontalVerticalConnector, postfix = HorizontalConnectorRight) {
                 HorizontalLine.repeat(it + 2)
             }
 
         return listOf(headingsTopBar, headingsLine, headingsBottomBar).joinToString("\n")
     }
 
-    private fun generateDataRows(): String {
-        val rowSeparator = maxColumnWidths
-            .joinToString(prefix = VerticalLine, separator = VerticalLine, postfix = VerticalLine) { " ".repeat(it + 2) }
-        // Iterate over format strings to build up each line with appropriate delimiters.
-        // Consider a function to do this so a row can easily be passed in.
-
-        val dataRows = data.joinToString("\n") {
-            val row = it.mapIndexed { index: Int, value: String ->
+    private fun generateDataRows(): String =
+        data.joinToString("\n") {
+            it.mapIndexed { index: Int, value: String ->
                 columnFormatStrings[index].format(value)
             }.joinToString(prefix = VerticalLine, separator = VerticalLine, postfix = VerticalLine)
-            listOf(row).joinToString("\n")
         }
 
-        return dataRows
-    }
+    private fun generateClosingRow(): String =
+        maxColumnWidths
+            .joinToString(prefix = BottomLeftCorner, separator = ColumnSeparatorBottom, postfix = BottomRightCorner) {
+                HorizontalLine.repeat(it + 2)
+            }
 
     object TableElements {
         const val TopLeftCorner = "┌"
@@ -74,8 +75,8 @@ class Table(private val headings: Array<String>, private val data: Array<Array<S
         const val HorizontalConnectorLeft = "├"
         const val HorizontalConnectorRight = "┤"
 
-        const val HeadingSeparatorTop = "┬"
-        const val HeadingSeparatorBottom = "┴"
+        const val ColumnSeparatorTop = "┬"
+        const val ColumnSeparatorBottom = "┴"
 
         const val HorizontalVerticalConnector = "┼"
     }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/output/Table.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.cli.output
+
+import uk.gov.justice.digital.cli.output.Table.TableElements.HeadingSeparatorBottom
+import uk.gov.justice.digital.cli.output.Table.TableElements.HeadingSeparatorTop
+import uk.gov.justice.digital.cli.output.Table.TableElements.HorizontalConnectorLeft
+import uk.gov.justice.digital.cli.output.Table.TableElements.HorizontalConnectorRight
+import uk.gov.justice.digital.cli.output.Table.TableElements.HorizontalLine
+import uk.gov.justice.digital.cli.output.Table.TableElements.TopLeftCorner
+import uk.gov.justice.digital.cli.output.Table.TableElements.TopRightCorner
+import uk.gov.justice.digital.cli.output.Table.TableElements.VerticalLine
+
+class Table(private val headings: Array<String>, private val data: Array<Array<String>>) {
+
+    private val maxColumnWidths = headings.map { it.length }
+
+    fun render(): String {
+        return generateColumnHeadings()
+    }
+
+    fun generateColumnHeadings(): String {
+        val headingsTopBar = headings
+            .joinToString(prefix = TopLeftCorner, separator = HeadingSeparatorTop, postfix = TopRightCorner) {
+                HorizontalLine.repeat(it.length + 2)
+            }
+        val headingsLine = headings.joinToString(prefix = VerticalLine, separator = VerticalLine, postfix = VerticalLine) { " $it " }
+        val headingsBottomBar = headings
+            .joinToString(prefix = HorizontalConnectorLeft, separator = HeadingSeparatorBottom, postfix = HorizontalConnectorRight) {
+                HorizontalLine.repeat(it.length + 2)
+            }
+
+        return listOf(headingsTopBar, headingsLine, headingsBottomBar).joinToString("\n")
+    }
+
+
+
+    object TableElements {
+        const val TopLeftCorner = "┌"
+        const val TopRightCorner = "┐"
+        const val BottomLeftCorner = "└"
+        const val BottomRightCorner = "┘"
+
+        const val HorizontalLine = "─"
+        const val VerticalLine = "│"
+
+        const val HorizontalConnectorLeft = "├"
+        const val HorizontalConnectorRight = "┤"
+
+        const val HeadingSeparatorTop = "┬"
+        const val HeadingSeparatorBottom = "┴"
+
+        const val HorizontalVerticalConnector = "┼"
+    }
+}

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
@@ -22,9 +22,9 @@ class DomainService(private val client: DomainClient) {
     @Inject
     private lateinit var objectMapper: ObjectMapper
 
-    fun getAllDomains(): Array<Domain> = client.getDomains()
+    fun getAllDomains(): List<Domain> = client.getDomains()
 
-    fun getDomains(name: String, status: Status? = null): Array<Domain> = client.getDomains(name, status)
+    fun getDomains(name: String, status: Status? = null): List<Domain> = client.getDomains(name, status)
 
     fun createDomain(domain: WriteableDomain): String = client.createDomain(domain)
 
@@ -45,7 +45,7 @@ class DomainService(private val client: DomainClient) {
         }
     }
 
-    fun previewDomain(name: String, status: Status, limit: Int): Array<Array<String>> =
+    fun previewDomain(name: String, status: Status, limit: Int): List<List<String?>> =
         client.previewDomain(name, status, limit)
 
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
@@ -45,6 +45,8 @@ class DomainService(private val client: DomainClient) {
         }
     }
 
+    fun previewDomain(name: String, status: Status): Array<Map<String, String>> = client.previewDomain(name, status)
+
 }
 
 sealed class DomainServiceException(message: String, cause: Exception? = null) : RuntimeException(message, cause)

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
@@ -45,7 +45,8 @@ class DomainService(private val client: DomainClient) {
         }
     }
 
-    fun previewDomain(name: String, status: Status): Array<Map<String, String>> = client.previewDomain(name, status)
+    fun previewDomain(name: String, status: Status, limit: Int): Array<Map<String, String>> =
+        client.previewDomain(name, status, limit)
 
 }
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/service/DomainService.kt
@@ -45,7 +45,7 @@ class DomainService(private val client: DomainClient) {
         }
     }
 
-    fun previewDomain(name: String, status: Status, limit: Int): Array<Map<String, String>> =
+    fun previewDomain(name: String, status: Status, limit: Int): Array<Array<String>> =
         client.previewDomain(name, status, limit)
 
 }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
@@ -19,6 +19,7 @@ import picocli.CommandLine
 import picocli.shell.jline3.PicocliCommands
 import uk.gov.justice.digital.headers.SessionIdHeader
 import java.io.ByteArrayInputStream
+import kotlin.text.Charsets.UTF_8
 
 interface ConsoleSession {
 
@@ -55,7 +56,7 @@ class InteractiveSession: ConsoleSession {
     // current terminal size less will be shown, allowing the user to scroll through the output. Otherwise the output
     // will just be printed directly to the screen.
     override fun print(s: String) {
-        less.run(Source.InputStreamSource(ByteArrayInputStream(toAnsi(s).toByteArray()), true, pagerText))
+        less.run(Source.InputStreamSource(ByteArrayInputStream(toAnsi(s).toByteArray(UTF_8)), true, pagerText))
     }
 
     fun terminal() = terminal
@@ -66,6 +67,7 @@ class InteractiveSession: ConsoleSession {
         try {
             this.terminal = TerminalBuilder
                 .builder()
+                .encoding(UTF_8)
                 .system(true)
                 .build()
             this.terminal.use { interactiveSession(commandLine, it) }

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
@@ -41,7 +41,7 @@ class BatchSession: ConsoleSession {
 @Singleton
 class InteractiveSession: ConsoleSession {
 
-    private val pagerText = "use arrow keys to move up and down | press q to exit this view | press h for help"
+    private val pagerText = " keys │ ↑ move up │ ↓ move down │ h help │ q exit this view "
 
     private lateinit var terminal: Terminal
 
@@ -49,6 +49,7 @@ class InteractiveSession: ConsoleSession {
         val l = Less(terminal, null)
         // Do not show pager if output will fit on the current screen
         l.quitIfOneScreen = true
+        l.chopLongLines = true
         l
     }
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
@@ -22,11 +22,9 @@ import java.io.ByteArrayInputStream
 import kotlin.text.Charsets.UTF_8
 
 interface ConsoleSession {
-
     fun print(s: String)
-
     fun toAnsi(s: String): String = CommandLine.Help.Ansi.AUTO.string(s)
-
+    fun isInteractive(): Boolean
 }
 
 @Singleton
@@ -35,6 +33,8 @@ class BatchSession: ConsoleSession {
     override fun print(s: String) {
         println(toAnsi(s))
     }
+
+    override fun isInteractive(): Boolean = false
 
 }
 
@@ -58,6 +58,8 @@ class InteractiveSession: ConsoleSession {
     override fun print(s: String) {
         less.run(Source.InputStreamSource(ByteArrayInputStream(toAnsi(s).toByteArray(UTF_8)), true, pagerText))
     }
+
+    override fun isInteractive(): Boolean = true
 
     fun terminal() = terminal
 

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/session/ConsoleSession.kt
@@ -41,7 +41,7 @@ class BatchSession: ConsoleSession {
 @Singleton
 class InteractiveSession: ConsoleSession {
 
-    private val pagerText = " keys │ ↑ move up │ ↓ move down │ h help │ q exit this view "
+    val pagerText = " keys │ ↑ move up │ ↓ move down │ ← move left │ → move right │ h help │ q exit "
 
     private lateinit var terminal: Terminal
 
@@ -49,7 +49,7 @@ class InteractiveSession: ConsoleSession {
         val l = Less(terminal, null)
         // Do not show pager if output will fit on the current screen
         l.quitIfOneScreen = true
-        l.chopLongLines = true
+        l.chopLongLines = true // Disable line wrap and allow left/right nav along long lines
         l
     }
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClientTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClientTest.kt
@@ -15,7 +15,6 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import uk.gov.justice.digital.cli.client.BlockingDomainClient
 import uk.gov.justice.digital.headers.Header
 import uk.gov.justice.digital.headers.Header.Companion.API_KEY_HEADER_NAME
 import uk.gov.justice.digital.model.Domain
@@ -115,7 +114,7 @@ class BlockingDomainClientTest {
         val actualResult =
             createClientForScenario(Scenarios.HAPPY_PATH).previewDomain("foo", Status.DRAFT, 100)
 
-        assertTrue(domainPreviewData.contentDeepEquals(actualResult))
+        assertEquals(domainPreviewData, actualResult)
     }
 
     @Requires(property = TEST_SCENARIO, value = Scenarios.HAPPY_PATH)
@@ -132,7 +131,7 @@ class BlockingDomainClientTest {
         @Post("/preview", consumes = [MediaType.APPLICATION_JSON], produces = [MediaType.APPLICATION_JSON])
         fun preview(@Suppress("UNUSED_PARAMETER") domainName: String,
                     @Suppress("UNUSED_PARAMETER") status: Status,
-                    @Suppress("UNUSED_PARAMETER") limit: Int): HttpResponse<Array<Array<String>>> {
+                    @Suppress("UNUSED_PARAMETER") limit: Int): HttpResponse<List<List<String?>>> {
             return HttpResponse.ok(domainPreviewData)
         }
     }

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClientTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClientTest.kt
@@ -6,6 +6,7 @@ import io.micronaut.http.HttpHeaders.USER_AGENT
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
@@ -20,7 +21,6 @@ import uk.gov.justice.digital.headers.Header.Companion.API_KEY_HEADER_NAME
 import uk.gov.justice.digital.model.Domain
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.model.WriteableDomain
-import uk.gov.justice.digital.test.Fixtures
 import uk.gov.justice.digital.test.Fixtures.TEST_API_KEY
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domain2
@@ -109,6 +109,14 @@ class BlockingDomainClientTest {
         assertEquals(sessionId, client.createDomain(writeableDomain))
     }
 
+    @Test
+    fun `previewDomain should return a list of data for a valid request`() {
+        val expectedData = listOf(
+            mapOf("foo" to "1", "bar" to "1", "baz" to "1")
+        )
+        assertEquals(expectedData, createClientForScenario(Scenarios.HAPPY_PATH).previewDomain("foo", Status.DRAFT, 100).toList())
+    }
+
     @Requires(property = TEST_SCENARIO, value = Scenarios.HAPPY_PATH)
     @Controller
     class HappyPathController {
@@ -120,6 +128,12 @@ class BlockingDomainClientTest {
         @Post("/domain")
         fun createDomain(@Suppress("UNUSED_PARAMETER") domain: WriteableDomain): HttpResponse<Unit> =
             HttpResponse.created(URI.create("/domain/$FIXED_UUID"))
+        @Post("/preview", consumes = [MediaType.APPLICATION_JSON], produces = [MediaType.APPLICATION_JSON])
+        fun preview(domainName: String, status: Status, limit: Int): HttpResponse<List<Map<String, String>>> {
+            return HttpResponse.ok(listOf(
+                mapOf("foo" to "1", "bar" to "1", "baz" to "1")
+            ))
+        }
     }
 
     @Requires(property = TEST_SCENARIO, value = Scenarios.NO_DATA)

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClientTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClientTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.model.WriteableDomain
 import uk.gov.justice.digital.test.Fixtures.TEST_API_KEY
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domain2
+import uk.gov.justice.digital.test.Fixtures.domainPreviewData
 import uk.gov.justice.digital.test.Fixtures.domains
 import uk.gov.justice.digital.test.Fixtures.writeableDomain
 import java.net.URI
@@ -111,10 +112,10 @@ class BlockingDomainClientTest {
 
     @Test
     fun `previewDomain should return a list of data for a valid request`() {
-        val expectedData = listOf(
-            mapOf("foo" to "1", "bar" to "1", "baz" to "1")
-        )
-        assertEquals(expectedData, createClientForScenario(Scenarios.HAPPY_PATH).previewDomain("foo", Status.DRAFT, 100).toList())
+        val actualResult =
+            createClientForScenario(Scenarios.HAPPY_PATH).previewDomain("foo", Status.DRAFT, 100)
+
+        assertTrue(domainPreviewData.contentDeepEquals(actualResult))
     }
 
     @Requires(property = TEST_SCENARIO, value = Scenarios.HAPPY_PATH)
@@ -129,10 +130,10 @@ class BlockingDomainClientTest {
         fun createDomain(@Suppress("UNUSED_PARAMETER") domain: WriteableDomain): HttpResponse<Unit> =
             HttpResponse.created(URI.create("/domain/$FIXED_UUID"))
         @Post("/preview", consumes = [MediaType.APPLICATION_JSON], produces = [MediaType.APPLICATION_JSON])
-        fun preview(domainName: String, status: Status, limit: Int): HttpResponse<List<Map<String, String>>> {
-            return HttpResponse.ok(listOf(
-                mapOf("foo" to "1", "bar" to "1", "baz" to "1")
-            ))
+        fun preview(@Suppress("UNUSED_PARAMETER") domainName: String,
+                    @Suppress("UNUSED_PARAMETER") status: Status,
+                    @Suppress("UNUSED_PARAMETER") limit: Int): HttpResponse<Array<Array<String>>> {
+            return HttpResponse.ok(domainPreviewData)
         }
     }
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ListDomainsTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ListDomainsTest.kt
@@ -30,19 +30,19 @@ class ListDomainsTest {
         underTest.run()
 
         val expectedOutput = """
-    
-            @|bold,green Found 3 domains|@
             
-            +----------+--------+--------------------+
-            | @|bold Name    |@ | @|bold Status|@ | @|bold Description       |@ |
-            +----------+--------+--------------------+
-            | Domain 1 | DRAFT  | A domain           |
-            | Domain 2 | DRAFT  | Another domain     |
-            | Domain 3 | DRAFT  | Yet another domain |
-            +----------+--------+--------------------+
-    
-    
-""".trimIndent()
+            @|bold,green Found 3 domains|@
+
+            ┌──────────┬────────┬────────────────────┐
+            │@|bold  Name     |@│@|bold  Status |@│@|bold  Description        |@│
+            ├──────────┼────────┼────────────────────┤
+            │ Domain 1 │ DRAFT  │ A domain           │
+            │ Domain 2 │ DRAFT  │ Another domain     │
+            │ Domain 3 │ DRAFT  │ Yet another domain │
+            └──────────┴────────┴────────────────────┘
+            
+            
+        """.trimIndent()
 
         assertEquals(expectedOutput, capturedOutput.joinToString(""))
     }

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ListDomainsTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ListDomainsTest.kt
@@ -64,7 +64,7 @@ class ListDomainsTest {
             @|bold No domains were found|@
             
     
-""".trimIndent()
+        """.trimIndent()
 
         assertEquals(expectedOutput, capturedOutput.joinToString(""))
     }

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ListDomainsTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ListDomainsTest.kt
@@ -25,7 +25,7 @@ class ListDomainsTest {
         underTest.parent = mockDomainBuilder
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.getAllDomains() } answers { arrayOf(domain1, domain2, domain3) }
+        every { mockDomainService.getAllDomains() } answers { listOf(domain1, domain2, domain3) }
 
         underTest.run()
 
@@ -55,7 +55,7 @@ class ListDomainsTest {
         underTest.parent = mockDomainBuilder
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.getAllDomains() } answers { emptyArray() }
+        every { mockDomainService.getAllDomains() } answers { emptyList() }
 
         underTest.run()
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -25,7 +25,8 @@ class PreviewDomainTest {
         underTest.domainStatus = Status.DRAFT
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.previewDomain(any(), any()) } answers {
+        every { mockDomainService.previewDomain(any(), any(), any()) } answers {
+            // TODO - define this in fixtures for use in other tests
             arrayOf(mapOf("foo" to "1", "bar" to "1", "baz" to "1"))
         }
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -42,7 +42,7 @@ class PreviewDomainTest {
 
         val expectedOutput = """
             
-            @|bold, green Previewing domain Domain 1 with status DRAFT|@
+            @|bold,green Previewing domain Domain 1 with status DRAFT|@
 
             ┌─────┬─────┬─────┐
             │@|bold  foo |@│@|bold  bar |@│@|bold  baz |@│

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.cli.DomainBuilder
 import uk.gov.justice.digital.cli.service.DomainService
 import uk.gov.justice.digital.model.Status
+import uk.gov.justice.digital.test.Fixtures.domainPreviewData
 
 class PreviewDomainTest {
 
@@ -25,14 +26,21 @@ class PreviewDomainTest {
         underTest.domainStatus = Status.DRAFT
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.previewDomain(any(), any(), any()) } answers {
-            // TODO - define this in fixtures for use in other tests
-            arrayOf(mapOf("foo" to "1", "bar" to "1", "baz" to "1"))
-        }
+        every { mockDomainService.previewDomain(any(), any(), any()) } answers { domainPreviewData }
 
         underTest.run()
 
-        val expectedOutput = "{foo=1, bar=1, baz=1}\n"
+        val expectedOutput = """
+            
+            @|bold, green Previewing domain Domain 1 with status DRAFT|@
+
+            ┌─────┬─────┬─────┐
+            │@|bold  foo |@│@|bold  bar |@│@|bold  baz |@│
+            ├─────┼─────┼─────┤
+            │ 1   │ 1   │ 1   │
+            └─────┴─────┴─────┘
+
+        """.trimIndent()
 
         assertEquals(expectedOutput, capturedOutput.joinToString(""))
     }

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.cli.command
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.cli.DomainBuilder
+
+class PreviewDomainTest {
+
+    private val mockDomainBuilder: DomainBuilder = mockk()
+
+    private val underTest = PreviewDomain()
+
+    @Test
+    fun `preview domain should generate some output`() {
+        val capturedOutput = mutableListOf<String>()
+
+        underTest.parent = mockDomainBuilder
+        underTest.domainNameElements = arrayOf("Domain 1")
+
+        every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+
+        underTest.run()
+
+        assertEquals("TODO\n", capturedOutput.joinToString(""))
+    }
+}

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.cli.command
 
 import io.mockk.every
 import io.mockk.mockk
+import org.jline.terminal.Terminal
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.cli.DomainBuilder
 import uk.gov.justice.digital.cli.service.DomainService
+import uk.gov.justice.digital.cli.session.InteractiveSession
 import uk.gov.justice.digital.model.Status
 import uk.gov.justice.digital.test.Fixtures.domainPreviewData
 
@@ -13,6 +15,8 @@ class PreviewDomainTest {
 
     private val mockDomainBuilder: DomainBuilder = mockk()
     private val mockDomainService: DomainService = mockk()
+    private val mockInteractiveSession: InteractiveSession = mockk()
+    private val mockTerminal: Terminal = mockk()
 
     private val underTest = PreviewDomain(mockDomainService)
 
@@ -25,7 +29,13 @@ class PreviewDomainTest {
         underTest.domainNameElements = arrayOf("Domain 1")
         underTest.domainStatus = Status.DRAFT
 
+        every { mockInteractiveSession.isInteractive() } answers { true }
+        every { mockInteractiveSession.terminal() } answers {mockTerminal }
+        every { mockTerminal.height } answers { 25 }
+
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+        every { mockDomainBuilder.session() } answers { mockInteractiveSession }
+        every { mockDomainBuilder.getInteractiveSession() } answers { mockInteractiveSession }
         every { mockDomainService.previewDomain(any(), any(), any()) } answers { domainPreviewData }
 
         underTest.run()

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -31,7 +31,7 @@ class PreviewDomainTest {
 
         underTest.run()
 
-        val expectedOutput = "{foo=1, bar=1, baz=1}i\n"
+        val expectedOutput = "{foo=1, bar=1, baz=1}\n"
 
         assertEquals(expectedOutput, capturedOutput.joinToString(""))
     }

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -47,7 +47,7 @@ class PreviewDomainTest {
             ┌─────┬─────┬─────┐
             │@|bold  foo |@│@|bold  bar |@│@|bold  baz |@│
             ├─────┼─────┼─────┤
-            │ 1   │ 1   │ 1   │
+            │ 1   │     │ 1   │
             └─────┴─────┴─────┘
 
         """.trimIndent()

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -5,24 +5,34 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.cli.DomainBuilder
+import uk.gov.justice.digital.cli.service.DomainService
+import uk.gov.justice.digital.model.Status
 
 class PreviewDomainTest {
 
     private val mockDomainBuilder: DomainBuilder = mockk()
+    private val mockDomainService: DomainService = mockk()
 
-    private val underTest = PreviewDomain()
+    private val underTest = PreviewDomain(mockDomainService)
 
     @Test
     fun `preview domain should generate some output`() {
         val capturedOutput = mutableListOf<String>()
 
         underTest.parent = mockDomainBuilder
+        // Ensure properties that are set via the CLI are initialized
         underTest.domainNameElements = arrayOf("Domain 1")
+        underTest.domainStatus = Status.DRAFT
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+        every { mockDomainService.previewDomain(any(), any()) } answers {
+            arrayOf(mapOf("foo" to "1", "bar" to "1", "baz" to "1"))
+        }
 
         underTest.run()
 
-        assertEquals("TODO\n", capturedOutput.joinToString(""))
+        val expectedOutput = "{foo=1, bar=1, baz=1}i\n"
+
+        assertEquals(expectedOutput, capturedOutput.joinToString(""))
     }
 }

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ViewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ViewDomainTest.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.table1
 import uk.gov.justice.digital.test.Fixtures.transform
 
-//  TODO - test handling of multiline query strings which should be flattened and trimmed
 class ViewDomainTest {
 
     private val mockDomainService: DomainService = mockk()

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ViewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/ViewDomainTest.kt
@@ -26,7 +26,7 @@ class ViewDomainTest {
         underTest.domainNameElements = arrayOf("Domain 1")
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.getDomains(any(), any()) } answers { arrayOf(domain1) }
+        every { mockDomainService.getDomains(any(), any()) } answers { listOf(domain1) }
 
         underTest.run()
 
@@ -64,7 +64,7 @@ class ViewDomainTest {
         underTest.domainNameElements = arrayOf("Domain 1")
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.getDomains(any(), any()) } answers { emptyArray() }
+        every { mockDomainService.getDomains(any(), any()) } answers { listOf() }
 
         underTest.run()
 
@@ -98,7 +98,7 @@ class ViewDomainTest {
         )
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
-        every { mockDomainService.getDomains(any(), any()) } answers { arrayOf(domainWithMultilineSQLString) }
+        every { mockDomainService.getDomains(any(), any()) } answers { listOf(domainWithMultilineSQLString) }
 
         underTest.run()
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.cli.output
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class TableTest {
+
+    private val underTest = Table(
+        arrayOf("heading1", "heading2", "heading3"),
+        arrayOf(
+            arrayOf("foo", "bar", "baz"),
+            arrayOf("a", "this value is much longer than the other fields", "baz"),
+        )
+    )
+
+    @Test
+    fun `it should render the table correctly`() {
+        val expectedOutput = """
+           ┌──────────┬──────────┬──────────┐
+           │ heading1 │ heading2 │ heading3 │
+           ├──────────┴──────────┴──────────┤
+        """.trimIndent()
+
+        assertEquals(expectedOutput, underTest.render())
+    }
+
+}

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
@@ -16,9 +16,11 @@ class TableTest {
     @Test
     fun `it should render the table correctly`() {
         val expectedOutput = """
-           ┌──────────┬──────────┬──────────┐
-           │ heading1 │ heading2 │ heading3 │
-           ├──────────┴──────────┴──────────┤
+            ┌──────────┬─────────────────────────────────────────────────┬──────────┐
+            │ heading1 │ heading2                                        │ heading3 │
+            ├──────────┴─────────────────────────────────────────────────┴──────────┤
+            │ foo      │ bar                                             │ baz      │
+            │ a        │ this value is much longer than the other fields │ baz      │
         """.trimIndent()
 
         assertEquals(expectedOutput, underTest.render())

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
@@ -9,18 +9,21 @@ class TableTest {
         arrayOf("heading1", "heading2", "heading3"),
         arrayOf(
             arrayOf("foo", "bar", "baz"),
-            arrayOf("a", "this value is much longer than the other fields", "baz"),
+            arrayOf("a", "this value is much longer than the other fields", "1"),
+            arrayOf("b", "", "foo"),
         )
     )
 
     @Test
-    fun `it should render the table correctly`() {
+    fun `it should render data as a table correctly`() {
         val expectedOutput = """
             ┌──────────┬─────────────────────────────────────────────────┬──────────┐
             │ heading1 │ heading2                                        │ heading3 │
-            ├──────────┴─────────────────────────────────────────────────┴──────────┤
+            ├──────────┼─────────────────────────────────────────────────┼──────────┤
             │ foo      │ bar                                             │ baz      │
-            │ a        │ this value is much longer than the other fields │ baz      │
+            │ a        │ this value is much longer than the other fields │ 1        │
+            │ b        │                                                 │ foo      │
+            └──────────┴─────────────────────────────────────────────────┴──────────┘
         """.trimIndent()
 
         assertEquals(expectedOutput, underTest.render())

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Test
 class TableTest {
 
     private val underTest = Table(
-        arrayOf("heading1", "heading2", "heading3"),
-        arrayOf(
-            arrayOf("foo", "bar", "baz"),
-            arrayOf("a", "this value is much longer than the other fields", "1"),
-            arrayOf("b", "", "foo"),
+        listOf("heading1", "heading2", "heading3"),
+        listOf(
+            listOf("foo", "bar", "baz"),
+            listOf("a", "this value is much longer than the other fields", "1"),
+            listOf("b", null, "foo"),
         )
     )
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/output/TableTest.kt
@@ -18,7 +18,7 @@ class TableTest {
     fun `it should render data as a table correctly`() {
         val expectedOutput = """
             ┌──────────┬─────────────────────────────────────────────────┬──────────┐
-            │ heading1 │ heading2                                        │ heading3 │
+            │@|bold  heading1 |@│@|bold  heading2                                        |@│@|bold  heading3 |@│
             ├──────────┼─────────────────────────────────────────────────┼──────────┤
             │ foo      │ bar                                             │ baz      │
             │ a        │ this value is much longer than the other fields │ 1        │

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/service/DomainServiceTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/service/DomainServiceTest.kt
@@ -9,8 +9,6 @@ import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.cli.client.DomainClient
-import uk.gov.justice.digital.cli.service.DomainService
-import uk.gov.justice.digital.cli.service.JsonParsingFailedException
 import uk.gov.justice.digital.cli.test.DomainJsonResources
 import uk.gov.justice.digital.test.Fixtures.domain1
 import uk.gov.justice.digital.test.Fixtures.domains
@@ -28,14 +26,14 @@ class DomainServiceTest {
 
     @Test
     fun `getDomains should return a list of domains`() {
-        every { mockDomainClient.getDomains() } returns domains.toTypedArray()
+        every { mockDomainClient.getDomains() } returns domains
         assertEquals(3, underTest.getAllDomains().size)
         verify { mockDomainClient.getDomains() }
     }
 
     @Test
     fun `getDomains should return a Domain given a name that exists`() {
-        every { mockDomainClient.getDomains(any(), any()) } returns arrayOf(domain1)
+        every { mockDomainClient.getDomains(any(), any()) } returns listOf(domain1)
 
         val name = "Domain 1"
         val result = underTest.getDomains(name)
@@ -46,7 +44,7 @@ class DomainServiceTest {
 
     @Test
     fun `getDomains should return null given a name that does not exist`() {
-        every { mockDomainClient.getDomains(any(), any()) } returns emptyArray()
+        every { mockDomainClient.getDomains(any(), any()) } returns emptyList()
         assertTrue(underTest.getDomains("This is not a valid domain name").isEmpty())
     }
 

--- a/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
+++ b/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
@@ -116,9 +116,10 @@ object Fixtures {
         }
     )
 
-    val domainPreviewData = arrayOf(
-        arrayOf("foo", "bar", "baz"),
-        arrayOf("1", "1", "1")
-    )
+    val domainPreviewData: List<List<String?>> =
+        listOf(
+            listOf("foo", "bar", "baz"),
+            listOf("1", null, "1")
+        )
 
 }

--- a/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
+++ b/common/src/testFixtures/kotlin/uk/gov/justice/digital/test/Fixtures.kt
@@ -116,4 +116,9 @@ object Fixtures {
         }
     )
 
+    val domainPreviewData = arrayOf(
+        arrayOf("foo", "bar", "baz"),
+        arrayOf("1", "1", "1")
+    )
+
 }


### PR DESCRIPTION
Summary of changes
* added preview support to client and service 
* factored out table generation for use in the list and preview views with dynamic column sizing
* revised preview data format and standardised on Lists throughout
* simplified interactive session detection to facilitate retrieving a dynamic number of rows according to terminal session screen height
* other minor changes including revised usage text for the `less` view