### PR TITLE
DPR-651 resolve issues identifed during QA

### DIFF
--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/client/BlockingDomainClient.kt
@@ -137,6 +137,7 @@ class BlockingDomainClient : DomainClient {
         val response: HttpResponse<String> = client.send(request, HttpResponse.BodyHandlers.ofString())
 
         if (response.statusCode() == 200) return response.deserialize(Argument.listOf(Argument.LIST_OF_STRING))
+        else if (response.statusCode() == 404) throw DomainNotFoundException("Domain with name: $name and status: $status was not found")
         else throw UnexpectedResponseException("Server returned an unexpected response: HTTP ${response.statusCode()}")
     }
 
@@ -174,4 +175,5 @@ class BlockingDomainClient : DomainClient {
 sealed class ClientException(message: String) : RuntimeException(message)
 class BadRequestException(message: String) : ClientException(message)
 class ConflictException(message: String) : ClientException(message)
+class DomainNotFoundException(message: String) : ClientException(message)
 class UnexpectedResponseException(message: String) : ClientException(message)

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ExceptionHandler.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/ExceptionHandler.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.cli.command
 import uk.gov.justice.digital.cli.DomainBuilder
 import uk.gov.justice.digital.cli.client.BadRequestException
 import uk.gov.justice.digital.cli.client.ConflictException
+import uk.gov.justice.digital.cli.client.DomainNotFoundException
 import uk.gov.justice.digital.cli.service.JsonParsingFailedException
 
 object ExceptionHandler {
@@ -29,7 +30,7 @@ object ExceptionHandler {
         catch (jpx: JsonParsingFailedException) {
             d.print("""
                 
-                @|red,bold Error: Could not create new domain|@
+                @|red,bold Could not create new domain|@
                 
                 @|white,bold Cause: ${jpx.localizedMessage}|@
                 
@@ -60,6 +61,20 @@ object ExceptionHandler {
                 else "\nNo reason was given.\n"
 
             d.print(errorDescription)
+        }
+        catch (dnfx: DomainNotFoundException) {
+            d.print("""
+                
+                @|red,bold There was a problem with your request|@
+                
+                @|white,bold ${dnfx.localizedMessage}|@
+                
+                @|blue,bold Possible fixes|@
+                
+                1. Use the list command to confirm that the domain exists with the status you requested
+                
+                
+            """.trimIndent())
         }
         catch (ex: Exception) {
             d.print("""

--- a/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
+++ b/cli/src/main/kotlin/uk/gov/justice/digital/cli/command/PreviewDomain.kt
@@ -53,11 +53,19 @@ class PreviewDomain(private val service: DomainService) : Runnable {
     override fun run() =
         runAndHandleExceptions(parent) {
             val result = service.previewDomain(domainName(), domainStatus, displayHeight())
-            val output = listOf(
-                "\n@|bold,green Previewing domain ${domainName()} with status ${domainStatus}|@\n",
-                generateOutput(result),
-                ""
-            ).joinToString("\n")
+            val output =
+                if (result.size > 1)
+                    listOf(
+                        "\n@|bold,green Previewing domain ${domainName()} with status ${domainStatus}|@\n",
+                        generateOutput(result),
+                        ""
+                    ).joinToString("\n")
+                else """
+                    
+                    @|bold,white Domain ${domainName()} with status $domainStatus is empty|@
+                    
+                """.trimIndent()
+
             parent.print(output)
         }
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/CreateDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/CreateDomainTest.kt
@@ -67,7 +67,7 @@ class CreateDomainTest {
 
         val expectedOutput = """
             
-            @|red,bold Error: Could not create new domain|@
+            @|red,bold Could not create new domain|@
 
             @|white,bold Cause: Unexpected character ('s' (code 115)): was expecting double-quote to start field name on line: 11 at column: 4|@
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -21,7 +21,7 @@ class PreviewDomainTest {
     private val underTest = PreviewDomain(mockDomainService)
 
     @Test
-    fun `preview domain should generate some output`() {
+    fun `preview domain should generate some output for a valid request`() {
         val capturedOutput = mutableListOf<String>()
 
         underTest.parent = mockDomainBuilder
@@ -30,7 +30,7 @@ class PreviewDomainTest {
         underTest.domainStatus = Status.DRAFT
 
         every { mockInteractiveSession.isInteractive() } answers { true }
-        every { mockInteractiveSession.terminal() } answers {mockTerminal }
+        every { mockInteractiveSession.terminal() } answers { mockTerminal }
         every { mockTerminal.height } answers { 25 }
 
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
@@ -49,6 +49,64 @@ class PreviewDomainTest {
             ├─────┼─────┼─────┤
             │ 1   │     │ 1   │
             └─────┴─────┴─────┘
+
+        """.trimIndent()
+
+        assertEquals(expectedOutput, capturedOutput.joinToString(""))
+    }
+
+    @Test
+    fun `preview domain should display a suitable message if no data was returned by the query`() {
+        val capturedOutput = mutableListOf<String>()
+
+        underTest.parent = mockDomainBuilder
+        // Ensure properties that are set via the CLI are initialized
+        underTest.domainNameElements = arrayOf("Domain 1")
+        underTest.domainStatus = Status.DRAFT
+
+        every { mockInteractiveSession.isInteractive() } answers { true }
+        every { mockInteractiveSession.terminal() } answers { mockTerminal }
+        every { mockTerminal.height } answers { 25 }
+
+        every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+        every { mockDomainBuilder.session() } answers { mockInteractiveSession }
+        every { mockDomainBuilder.getInteractiveSession() } answers { mockInteractiveSession }
+        every { mockDomainService.previewDomain(any(), any(), any()) } answers { domainPreviewData.subList(0, 1) }
+
+        underTest.run()
+
+        val expectedOutput = """
+            
+            @|bold,white Domain Domain 1 with status DRAFT is empty|@
+
+        """.trimIndent()
+
+        assertEquals(expectedOutput, capturedOutput.joinToString(""))
+    }
+
+    @Test
+    fun `preview domain should display a suitable message if the domain was not found`() {
+        val capturedOutput = mutableListOf<String>()
+
+        underTest.parent = mockDomainBuilder
+        // Ensure properties that are set via the CLI are initialized
+        underTest.domainNameElements = arrayOf("Domain 1")
+        underTest.domainStatus = Status.DRAFT
+
+        every { mockInteractiveSession.isInteractive() } answers { true }
+        every { mockInteractiveSession.terminal() } answers { mockTerminal }
+        every { mockTerminal.height } answers { 25 }
+
+        every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
+        every { mockDomainBuilder.session() } answers { mockInteractiveSession }
+        every { mockDomainBuilder.getInteractiveSession() } answers { mockInteractiveSession }
+        every { mockDomainService.previewDomain(any(), any(), any()) } answers { domainPreviewData.subList(0, 1) }
+
+        underTest.run()
+
+        val expectedOutput = """
+            
+            @|bold,white Domain Domain 1 with status DRAFT is empty|@
 
         """.trimIndent()
 

--- a/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
+++ b/cli/src/test/kotlin/uk/gov/justice/digital/cli/command/PreviewDomainTest.kt
@@ -6,6 +6,7 @@ import org.jline.terminal.Terminal
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.cli.DomainBuilder
+import uk.gov.justice.digital.cli.client.DomainNotFoundException
 import uk.gov.justice.digital.cli.service.DomainService
 import uk.gov.justice.digital.cli.session.InteractiveSession
 import uk.gov.justice.digital.model.Status
@@ -100,13 +101,20 @@ class PreviewDomainTest {
         every { mockDomainBuilder.print(capture(capturedOutput)) } answers {  }
         every { mockDomainBuilder.session() } answers { mockInteractiveSession }
         every { mockDomainBuilder.getInteractiveSession() } answers { mockInteractiveSession }
-        every { mockDomainService.previewDomain(any(), any(), any()) } answers { domainPreviewData.subList(0, 1) }
+        every { mockDomainService.previewDomain(any(), any(), any()) } throws(DomainNotFoundException("Domain with name: Domain 1 and status: DRAFT was not found"))
 
         underTest.run()
 
         val expectedOutput = """
             
-            @|bold,white Domain Domain 1 with status DRAFT is empty|@
+            @|red,bold There was a problem with your request|@
+
+            @|white,bold Domain with name: Domain 1 and status: DRAFT was not found|@
+
+            @|blue,bold Possible fixes|@
+
+            1. Use the list command to confirm that the domain exists with the status you requested
+
 
         """.trimIndent()
 


### PR DESCRIPTION
Summary of changes
* empty results from the backend now show a 'domain empty' message
* if the specified preview domain is not found a dedicated error message is show rather than simply reporting the 404 returned by the backend 